### PR TITLE
Konverterer gjennomføringsstatus

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/amt/AmtGjennomforing.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/amt/AmtGjennomforing.kt
@@ -12,5 +12,12 @@ data class AmtGjennomforing(
 	val startDato: LocalDate?,
 	val sluttDato: LocalDate?,
 	val registrertDato: LocalDateTime,
-	val fremmoteDato: LocalDateTime?
-)
+	val fremmoteDato: LocalDateTime?,
+	val status: Status
+) {
+	enum class Status {
+		IKKE_STARTET,
+		GJENNOMFORES,
+		AVSLUTTET
+	}
+}

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/GjennomforingStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/GjennomforingStatusConverter.kt
@@ -1,0 +1,21 @@
+package no.nav.amt.arena.acl.processors
+
+import no.nav.amt.arena.acl.domain.amt.AmtGjennomforing
+import org.springframework.dao.DataIntegrityViolationException
+
+class GjennomforingStatusConverter {
+
+	val avsluttendeStatuser = listOf("AVLYST", "AVBRUTT", "AVSLUTT")
+	val ikkeStartetStatuser = listOf("PLANLAGT")
+	val gjennomforesStatuser = listOf("GJENNOMFOR")
+
+	fun convert (arenaStatus: String) : AmtGjennomforing.Status {
+		return when (arenaStatus) {
+			in avsluttendeStatuser -> AmtGjennomforing.Status.AVSLUTTET
+			in ikkeStartetStatuser -> AmtGjennomforing.Status.IKKE_STARTET
+			in gjennomforesStatuser -> AmtGjennomforing.Status.GJENNOMFORES
+			else -> throw DataIntegrityViolationException("Ukjent status fra arena: ${arenaStatus}")
+		}
+
+	}
+}

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/TiltakGjennomforingProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/TiltakGjennomforingProcessor.kt
@@ -38,6 +38,7 @@ open class TiltakGjennomforingProcessor(
 ) {
 
 	private val logger = LoggerFactory.getLogger(javaClass)
+	private val statusConverter = GjennomforingStatusConverter()
 
 	override fun handleEntry(data: ArenaData) {
 		val arenaGjennomforing = getMainObject(data)
@@ -143,7 +144,8 @@ open class TiltakGjennomforingProcessor(
 			startDato = DATO_FRA?.asLocalDate(),
 			sluttDato = DATO_TIL?.asLocalDate(),
 			registrertDato = REG_DATO.asLocalDateTime(),
-			fremmoteDato = DATO_FREMMOTE?.asLocalDate() withTime KLOKKETID_FREMMOTE.asTime()
+			fremmoteDato = DATO_FREMMOTE?.asLocalDate() withTime KLOKKETID_FREMMOTE.asTime(),
+			status = statusConverter.convert(TILTAKSTATUSKODE)
 		)
 	}
 

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/GjennomforingStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/GjennomforingStatusConverterTest.kt
@@ -1,0 +1,30 @@
+package no.nav.amt.arena.acl.processors
+
+import io.kotest.matchers.shouldBe
+import no.nav.amt.arena.acl.domain.amt.AmtGjennomforing
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class GjennomforingStatusConverterTest {
+	val converter = GjennomforingStatusConverter()
+
+	@Test
+	fun `convert() - konverterer avlyst til AVSLUTTET`() {
+		converter.convert("AVLYST") shouldBe AmtGjennomforing.Status.AVSLUTTET
+	}
+
+	@Test
+	fun `convert() - konverterer planlagt til IKKE_STARTET`() {
+		converter.convert("PLANLAGT") shouldBe AmtGjennomforing.Status.IKKE_STARTET
+	}
+
+	@Test
+	fun `convert() - konverterer planlagt til GJENNOMFORES`() {
+		converter.convert("GJENNOMFOR") shouldBe AmtGjennomforing.Status.GJENNOMFORES
+	}
+
+	@Test
+	fun `convert() - ukjent status - kaster exception `() {
+		assertThrows<RuntimeException> { converter.convert("BLABLA") }
+	}
+}


### PR DESCRIPTION
https://trello.com/c/oXlp0WDM/149-vise-kun-tiltaksgjennomf%C3%B8ringer-som-gjennomf%C3%B8res