### PR TITLE
Ikke re-ingest deltakere på INVALID tiltak før nytt gyldig tiltak har blitt ingested

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
@@ -201,18 +201,18 @@ open class ArenaDataRepository(
 	): List<ArenaDataDbo> {
 		val sql = """
 			SELECT *
-				FROM arena_data deltaker join arena_data tiltak on deltaker.after ->> 'TILTAKGJENNOMFORING_ID' = tiltak.arena_id
-				WHERE deltaker.arena_table_name = :tableName
-				  AND tiltak.arena_table_name = :dependencyTableName
-				  AND deltaker.ingest_status = :ingestStatuses
-				  AND tiltak.ingest_status = :tiltakStatus
+				FROM arena_data deltaker join arena_data gjennomforing on deltaker.after ->> 'TILTAKGJENNOMFORING_ID' = gjennomforing.arena_id
+				WHERE deltaker.arena_table_name = '$ARENA_DELTAKER_TABLE_NAME'
+				  AND gjennomforing.arena_table_name = '$ARENA_GJENNOMFORING_TABLE_NAME'
+				  AND deltaker.ingest_status IN (:ingestStatuses)
+				  AND gjennomforing.ingest_status = :gjennomforingStatus
 		""".trimIndent()
 
 		val parameters = sqlParameters(
 			"ingestStatuses" to statuses.map { it.name }.toSet(),
 			"tableName" to ARENA_DELTAKER_TABLE_NAME,
 			"dependencyTableName" to ARENA_GJENNOMFORING_TABLE_NAME,
-			"tiltakStatus" to IngestStatus.HANDLED.toString(),
+			"gjennomforingStatus" to IngestStatus.HANDLED.toString(),
 			"offset" to offset,
 			"limit" to limit
 		)

--- a/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
@@ -36,14 +36,15 @@ open class RetryArenaMessageProcessorService(
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_TILTAK_TABLE_NAME, IngestStatus.RETRY))
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_SAK_TABLE_NAME, IngestStatus.RETRY))
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_GJENNOMFORING_TABLE_NAME, IngestStatus.RETRY))
-		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_DELTAKER_TABLE_NAME, IngestStatus.RETRY))
+		processBatch(arenaDataRepository.getReingestableDeltakerWithStatus(IngestStatus.RETRY))
+
 	}
 
 	fun processFailedMessages() {
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_TILTAK_TABLE_NAME, IngestStatus.FAILED))
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_SAK_TABLE_NAME, IngestStatus.FAILED))
 		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_GJENNOMFORING_TABLE_NAME, IngestStatus.FAILED))
-		processBatch(arenaDataRepository.getByIngestStatusIn(ARENA_DELTAKER_TABLE_NAME, IngestStatus.FAILED))
+		processBatch(arenaDataRepository.getReingestableDeltakerWithStatus(IngestStatus.FAILED))
 	}
 
 	private fun processBatch(entries: List<ArenaDataDbo>) {


### PR DESCRIPTION
Fikser feilen:
Gitt at deltaker på INVALID tiltak blir ingested, så vil de få status RETRY og forsøkes å reingestes på lik linje med de som har feilet av andre årsaker. Dette er mange deltakere som fyller opp limit på 500 slik at andre deltakere ikke blir forsøkt.

Løsning hvor deltakerProcessor må kjenne til status på arena data på tiltaksgjennomføring, evt triggering av ingest på deltaker når tiltak går fra INVALID til HANDLED, virker hårete

https://trello.com/c/thmDmRlQ/356-feils%C3%B8ke-deltakere-med-failed-status-i-arenadata-prod
