### PR TITLE
Filtrer vekk deltakere med status som ikke skal vises til tiltaksarrangør

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -37,6 +37,10 @@ open class DeltakerProcessor(
 		val arenaDeltaker = message.getData()
 		val arenaGjennomforingId = arenaDeltaker.TILTAKGJENNOMFORING_ID.toString()
 
+		if (harStatusSomSkalIgnoreres(arenaDeltaker.DELTAKERSTATUSKODE)) {
+			throw IgnoredException("Deltakeren har status=${arenaDeltaker.DELTAKERSTATUSKODE} som ikke skal håndteres")
+		}
+
 		val gjennomforingInfo =
 			arenaDataIdTranslationService.findGjennomforingIdTranslation(arenaGjennomforingId)
 				?: throw DependencyNotIngestedException("Venter på at gjennomføring med id=$arenaGjennomforingId skal bli håndtert")
@@ -110,6 +114,11 @@ open class DeltakerProcessor(
 			statusEndretDato = converter.getEndretDato(),
 			innsokBegrunnelse = innsokBegrunnelse
 		)
+	}
+
+	private fun harStatusSomSkalIgnoreres(arenaDeltakerStatusKode: String): Boolean {
+		val statuserSomIgnoreres = listOf("VENTELISTE", "AKTUELL", "JATAKK", "INFOMOETE")
+		return statuserSomIgnoreres.contains(arenaDeltakerStatusKode)
 	}
 
 }

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessorTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessorTest.kt
@@ -117,6 +117,21 @@ class DeltakerProcessorTest : FunSpec({
 		translationEntry!!.ignored shouldBe false
 	}
 
+	test("Skal kaste ignored exception for ignorerte statuser") {
+		val statuser = listOf("VENTELISTE", "AKTUELL", "JATAKK", "INFOMOETE")
+
+		statuser.forEachIndexed { idx, status ->
+			shouldThrowExactly<IgnoredException> {
+				deltakerProcessor.handleArenaMessage(createArenaDeltakerKafkaMessage(
+					position = UUID.randomUUID().toString(),
+					tiltakGjennomforingArenaId = nonIgnoredGjennomforingArenaId,
+					deltakerArenaId = idx.toLong(),
+					deltakerStatusKode = status
+				))
+			}
+		}
+	}
+
 	test("Insert Deltaker with gjennomføring not processed should throw exception") {
 		val position = UUID.randomUUID().toString()
 

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/ProcessorTestUtils.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/ProcessorTestUtils.kt
@@ -16,7 +16,7 @@ fun createArenaDeltakerKafkaMessage(
 	arenaPersonId: Long = 100L,
 	oppstartDato: LocalDate? = null,
 	sluttDato: LocalDate? = null,
-	deltakerStatusKode: String = "AKTUELL",
+	deltakerStatusKode: String = "GJENN",
 	statusEndringDato: LocalDate? = null,
 	dagerPerUke: Int? = null,
 	prosentDeltid: Float = 0.0f,


### PR DESCRIPTION
Jeg ser for meg at i fremtiden når vi eier alle tiltak og statuser, at vi heller ønsker å mappe om disse statusene og sende de videre til amt-tiltak, hvor det vil bli filtrert vekk slik at de ikke vises i frontend