### PR TITLE
Retter feil som gjør at ugyldige gjennomføringer står og feiler og forsøkes reingestes

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/GjennomforingProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/GjennomforingProcessor.kt
@@ -10,7 +10,7 @@ import no.nav.amt.arena.acl.services.GjennomforingService
 import no.nav.amt.arena.acl.utils.ARENA_DELTAKER_TABLE_NAME
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import java.util.UUID
+import java.util.*
 
 @Component
 open class GjennomforingProcessor(
@@ -36,13 +36,16 @@ open class GjennomforingProcessor(
 			return
 		}
 
-		val gjennomforingId = getGjennomforingId(arenaId)
-		gjennomforingService.setGjennomforingId(arenaId, gjennomforingId)
+		kotlin.runCatching {
+			val gjennomforingId = getGjennomforingId(arenaId)
+			gjennomforingService.setGjennomforingId(arenaId, gjennomforingId)
+		}
+
+		if(isValid) {
+			retryDeltakere()
+		}
 
 		arenaDataRepository.upsert(message.toUpsertInputWithStatusHandled(arenaId))
-
-		if(isValid) retryDeltakere()
-
 		log.info("Gjennomføring $arenaId er ferdig håndtert")
 
 	}


### PR DESCRIPTION
https://trello.com/c/RLozs57k/890-gjennomf%C3%B8ringer-uten-arrang%C3%B8r-id-st%C3%A5r-og-feiler