### PR TITLE
aktuell, infomøte og venteliste skal mappes likt uavhengig av inntaks…

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
@@ -20,8 +20,8 @@ class ArenaDeltakerStatusConverter(
 
 	fun convert(): DeltakerStatus {
 		val status =
-			if (erKurs) convertKursStatuser()
-			else if (arenaStatus.erSoktInn()) DeltakerStatus(AmtDeltaker.Status.PABEGYNT_REGISTRERING, datoStatusEndring)
+			if (arenaStatus.erSoktInn()) utledSoktInnStatus()
+			else if (erKurs) convertKursStatuser()
 			else if (arenaStatus.erGjennomforende()) utledGjennomforendeStatus()
 			else if (arenaStatus.erAvsluttende()) utledAvsluttendeStatus()
 			else if (arenaStatus.erIkkeAktuell()) utledIkkeAkuelleStatus()

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
@@ -15,10 +15,10 @@ private val now = LocalDateTime.now()
 class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	val erGjennomforingAvsluttet = false
 
-	"status - AKTUELL - returnerer PABEGYNT" {
+	"status - AKTUELL - returnerer SOKT_INN" {
 		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
 
-		status.navn shouldBe PABEGYNT_REGISTRERING
+		status.navn shouldBe SOKT_INN
 	}
 
 	"status - AVSLAG og mangler startdato - returnerer IKKE_AKTUELL" {
@@ -268,7 +268,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			erGjennomforingAvsluttet, LocalDate.now(), false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
-	"status - INFOMOETE - returnerer PABEGYNT" {
+	"status - INFOMOETE - returnerer VURDERES" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.INFOMOETE,
 			now,
@@ -276,7 +276,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			erGjennomforingAvsluttet, LocalDate.now(), false
-		).convert().navn shouldBe PABEGYNT_REGISTRERING
+		).convert().navn shouldBe VURDERES
 	}
 	"status - JATAKK - returnerer VENTER_PÅ_OPPSTART" {
 		ArenaDeltakerStatusConverter(
@@ -388,7 +388,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			erGjennomforingAvsluttet, LocalDate.now(), false
 		).convert().navn shouldBe DELTAR
 	}
-	"status - PABEGYNT - returnerer VENTER_PÅ_OPPSTART" {
+	"status - VENTELISTE - returnerer VENTELISTE" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.VENTELISTE,
 			now,
@@ -396,7 +396,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			erGjennomforingAvsluttet, LocalDate.now(), false
-		).convert().navn shouldBe PABEGYNT_REGISTRERING
+		).convert().navn shouldBe VENTELISTE
 	}
 
 	"convert - VENTELISTE på kurstiltak - returnerer VENTELISTE" {


### PR DESCRIPTION
…type

https://trello.com/c/J7eQJvtj/1226-endre-mapping-fra-arenastatus-til-v%C3%A5re-statuser