### PR TITLE
Slettede deltakere engangsjobb

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
@@ -1,0 +1,80 @@
+package no.nav.amt.arena.acl.controller
+
+import jakarta.servlet.http.HttpServletRequest
+import no.nav.amt.arena.acl.domain.db.ArenaDataDbo
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtKafkaMessageDto
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtOperation
+import no.nav.amt.arena.acl.domain.kafka.amt.PayloadType
+import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltaker
+import no.nav.amt.arena.acl.exceptions.IgnoredException
+import no.nav.amt.arena.acl.processors.DeltakerProcessor
+import no.nav.amt.arena.acl.repositories.ArenaDataRepository
+import no.nav.amt.arena.acl.services.KafkaProducerService
+import no.nav.amt.arena.acl.utils.JsonUtils.fromJsonString
+import no.nav.security.token.support.core.api.Unprotected
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@Unprotected
+@RestController
+@RequestMapping("/internal/api")
+class InternalController(
+	private val arenaDataRepository: ArenaDataRepository,
+	private val deltakerProcessor: DeltakerProcessor,
+	private val kafkaProducerService: KafkaProducerService,
+) {
+	private val log = LoggerFactory.getLogger(javaClass)
+
+	@GetMapping("/rekonstruer-slettede-deltakere")
+	fun fjernTilgangerHosArrangor(
+		request: HttpServletRequest,
+	) {
+		if (!isInternal(request)) {
+			throw ResponseStatusException(HttpStatus.UNAUTHORIZED)
+		}
+
+		val slettedeDeltakere = arenaDataRepository.getDeleteDeltakerRecords()
+		log.info("Fant ${slettedeDeltakere.size} slettede deltakere")
+		slettedeDeltakere.forEach {
+			handleSlettetDeltaker(it)
+		}
+		log.info("Ferdig med å håndtere slettede deltakere")
+	}
+
+	private fun handleSlettetDeltaker(arenaDataDbo: ArenaDataDbo) {
+		val arenaDeltakerRaw = arenaDataDbo.before?.let { fromJsonString<ArenaDeltaker>(it) }
+			?: throw IllegalStateException("Slettet deltaker med arenaId ${arenaDataDbo.arenaId} mangler before")
+		val arenaDeltakerId = arenaDeltakerRaw.TILTAKDELTAKER_ID.toString()
+		val arenaGjennomforingId = arenaDeltakerRaw.TILTAKGJENNOMFORING_ID.toString()
+
+		if (!arenaDeltakerRaw.EKSTERN_ID.isNullOrEmpty()) {
+			log.info("Ignorerer deltaker som har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
+			return
+		}
+
+		val gjennomforing = try {
+			deltakerProcessor.getGjennomforing(arenaGjennomforingId)
+		} catch (e: IgnoredException) {
+			log.info(e.message)
+			return
+		}
+		val deltaker = deltakerProcessor.createDeltaker(arenaDeltakerRaw, gjennomforing)
+
+		val deltakerKafkaMessage = AmtKafkaMessageDto(
+			type = PayloadType.DELTAKER,
+			operation = AmtOperation.CREATED,
+			payload = deltaker
+		)
+		kafkaProducerService.sendTilAmtTiltak(deltaker.id, deltakerKafkaMessage)
+
+		log.info("Melding for tidligere slettet deltaker id=${deltaker.id} arenaId=$arenaDeltakerId transactionId=${deltakerKafkaMessage.transactionId} op=${deltakerKafkaMessage.operation} er sendt")
+	}
+
+	private fun isInternal(request: HttpServletRequest): Boolean {
+		return request.remoteAddr == "127.0.0.1"
+	}
+}

--- a/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
@@ -6,7 +6,6 @@ import no.nav.amt.arena.acl.domain.kafka.amt.AmtKafkaMessageDto
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtOperation
 import no.nav.amt.arena.acl.domain.kafka.amt.PayloadType
 import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltaker
-import no.nav.amt.arena.acl.exceptions.IgnoredException
 import no.nav.amt.arena.acl.processors.DeltakerProcessor
 import no.nav.amt.arena.acl.repositories.ArenaDataRepository
 import no.nav.amt.arena.acl.services.KafkaProducerService
@@ -58,8 +57,8 @@ class InternalController(
 
 		val gjennomforing = try {
 			deltakerProcessor.getGjennomforing(arenaGjennomforingId)
-		} catch (e: IgnoredException) {
-			log.info(e.message)
+		} catch (e: Exception) {
+			log.error(e.message)
 			return
 		}
 		val deltaker = deltakerProcessor.createDeltaker(arenaDeltakerRaw, gjennomforing)

--- a/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/controller/InternalController.kt
@@ -58,7 +58,7 @@ class InternalController(
 		val gjennomforing = try {
 			deltakerProcessor.getGjennomforing(arenaGjennomforingId)
 		} catch (e: Exception) {
-			log.error(e.message)
+			log.error("${e.message}, arenaid $arenaDeltakerId")
 			return
 		}
 		val deltaker = deltakerProcessor.createDeltaker(arenaDeltakerRaw, gjennomforing)

--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
@@ -35,7 +35,8 @@ data class TiltakDeltaker(
 		VENTELISTE,
 		AKTUELL,
 		JATAKK,
-		INFOMOETE
+		INFOMOETE,
+		FEILREG
 	}
 
 	enum class StatusAarsak {

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -96,7 +96,8 @@ open class DeltakerProcessor(
 		return eldreMeldingVenter != null
 	}
 
-	private fun createDeltaker(arenaDeltakerRaw: ArenaDeltaker, gjennomforing: Gjennomforing): AmtDeltaker {
+	// skal gjøres private igjen etter engangsjobb
+	fun createDeltaker(arenaDeltakerRaw: ArenaDeltaker, gjennomforing: Gjennomforing): AmtDeltaker {
 		val arenaDeltaker = arenaDeltakerRaw
 			.tryRun { it.mapTiltakDeltaker() }
 			.getOrThrow()
@@ -116,7 +117,8 @@ open class DeltakerProcessor(
 		)
 	}
 
-	private fun getGjennomforing(arenaGjennomforingId: String): Gjennomforing {
+	// skal gjøres private igjen etter engangsjobb
+	fun getGjennomforing(arenaGjennomforingId: String): Gjennomforing {
 		val gjennomforing = gjennomforingService.get(arenaGjennomforingId)
 			?: throw DependencyNotIngestedException("Venter på at gjennomføring med id=$arenaGjennomforingId skal bli håndtert")
 

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -8,6 +8,7 @@ import no.nav.amt.arena.acl.domain.db.IngestStatus
 import no.nav.amt.arena.acl.domain.db.toUpsertInputWithStatusHandled
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtKafkaMessageDto
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtOperation
 import no.nav.amt.arena.acl.domain.kafka.amt.PayloadType
 import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltaker
 import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltakerKafkaMessage
@@ -63,16 +64,20 @@ open class DeltakerProcessor(
 			Thread.sleep(500)
 		}
 
-		val deltakerKafkaMessage = AmtKafkaMessageDto(
-			type = PayloadType.DELTAKER,
-			operation = message.operationType,
-			payload = deltaker
-		)
+		if (message.operationType != AmtOperation.DELETED) {
+			val deltakerKafkaMessage = AmtKafkaMessageDto(
+				type = PayloadType.DELTAKER,
+				operation = message.operationType,
+				payload = deltaker
+			)
 
-		kafkaProducerService.sendTilAmtTiltak(deltaker.id, deltakerKafkaMessage)
+			kafkaProducerService.sendTilAmtTiltak(deltaker.id, deltakerKafkaMessage)
+			log.info("Melding for deltaker id=${deltaker.id} arenaId=$arenaDeltakerId transactionId=${deltakerKafkaMessage.transactionId} op=${deltakerKafkaMessage.operation} er sendt")
+		} else {
+			log.info("Mottatt delete-melding for deltaker id=${deltaker.id} arenaId=$arenaDeltakerId, blir ikke behandlet")
+		}
+
 		arenaDataRepository.upsert(message.toUpsertInputWithStatusHandled(arenaDeltakerId))
-
-		log.info("Melding for deltaker id=${deltaker.id} arenaId=$arenaDeltakerId transactionId=${deltakerKafkaMessage.transactionId} op=${deltakerKafkaMessage.operation} er sendt")
 		metrics.publishMetrics(message)
 	}
 
@@ -117,7 +122,6 @@ open class DeltakerProcessor(
 		)
 	}
 
-	// skal gjøres private igjen etter engangsjobb
 	fun getGjennomforing(arenaGjennomforingId: String): Gjennomforing {
 		val gjennomforing = gjennomforingService.get(arenaGjennomforingId)
 			?: throw DependencyNotIngestedException("Venter på at gjennomføring med id=$arenaGjennomforingId skal bli håndtert")

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
@@ -21,6 +21,7 @@ class ArenaDeltakerStatusConverter(
 	fun convert(): DeltakerStatus {
 		val status =
 			if (arenaStatus.erSoktInn()) utledSoktInnStatus()
+			else if (arenaStatus.erFeilregistrert()) utledFeilregistrertStatus()
 			else if (erKurs) convertKursStatuser()
 			else if (arenaStatus.erGjennomforende()) utledGjennomforendeStatus()
 			else if (arenaStatus.erAvsluttende()) utledAvsluttendeStatus()
@@ -127,6 +128,8 @@ class ArenaDeltakerStatusConverter(
 		else return DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, datoStatusEndring)
 	}
 
+	private fun utledFeilregistrertStatus(): DeltakerStatus =
+		DeltakerStatus(AmtDeltaker.Status.FEILREGISTRERT, datoStatusEndring)
 
 	private fun TiltakDeltaker.Status.erAvsluttende(): Boolean {
 		return this in listOf(
@@ -162,4 +165,7 @@ class ArenaDeltakerStatusConverter(
 		)
 	}
 
+	private fun TiltakDeltaker.Status.erFeilregistrert(): Boolean {
+		return this == TiltakDeltaker.Status.FEILREG
+	}
 }

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
@@ -206,6 +206,7 @@ open class ArenaDataRepository(
 			FROM arena_data
 			WHERE operation_type='DELETED'
 			AND arena_table_name = '$ARENA_DELTAKER_TABLE_NAME'
+			ORDER BY operation_timestamp
 		""".trimIndent()
 
 		return template.query(sql, rowMapper)

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataRepository.kt
@@ -200,6 +200,17 @@ open class ArenaDataRepository(
 		return template.query(sql, logRowMapper)
 	}
 
+	fun getDeleteDeltakerRecords(): List<ArenaDataDbo> {
+		val sql = """
+			SELECT *
+			FROM arena_data
+			WHERE operation_type='DELETED'
+			AND arena_table_name = '$ARENA_DELTAKER_TABLE_NAME'
+		""".trimIndent()
+
+		return template.query(sql, rowMapper)
+	}
+
 	fun getAll(): List<ArenaDataDbo> {
 		val sql = """
 			SELECT *

--- a/src/test/kotlin/no/nav/amt/arena/acl/integration/DeltakerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/integration/DeltakerIntegrationTest.kt
@@ -299,7 +299,7 @@ class DeltakerIntegrationTest : IntegrationTestBase() {
 
 
 	@Test
-	fun `slett deltaker - deltaker blir slettet`() {
+	fun `slett deltaker - deltaker blir ikke slettet, melding blir handled`() {
 		mockArenaOrdsProxyHttpServer.mockHentFnr(baseDeltaker.PERSON_ID!!, fnr)
 
 		gjennomforingService.upsert(baseGjennomforing.TILTAKGJENNOMFORING_ID.toString(), SUPPORTED_TILTAK.first(), true)
@@ -319,6 +319,8 @@ class DeltakerIntegrationTest : IntegrationTestBase() {
 		AsyncUtils.eventually {
 			val arenaData = arenaDataRepository.get(ARENA_DELTAKER_TABLE_NAME, AmtOperation.DELETED, pos)
 			arenaData!!.ingestStatus shouldBe IngestStatus.HANDLED
+			val deltakerRecord = kafkaMessageConsumer.getLatestRecord(KafkaMessageConsumer.Topic.AMT_TILTAK)
+			deltakerRecord shouldBe null
 		}
 	}
 

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
@@ -21,6 +21,12 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 		status.navn shouldBe SOKT_INN
 	}
 
+	"status - FEILREG - returnerer FEILREGISTRERT" {
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FEILREG, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+
+		status.navn shouldBe FEILREGISTRERT
+	}
+
 	"status - AVSLAG og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.AVSLAG,


### PR DESCRIPTION
https://trello.com/c/9Arr5xdK/1639-lese-inn-historiserte-deltakere-fra-arena

Engangsjobb for å få lest inn forrige versjon (before) av deltakere som har blitt slettet for å få mest mulig korrekte data (både innsøktdato og opprinnelig deltakerId). 

Det tikker stadig inn slettemeldinger, så for å unngå at vi ikke får med alle måtte jeg legge inn at vi ikke skal slette deltakere mer allerede her. La også inn feilregistrert-statusen. 

Tanken er å fjerne internalcontrolleren når jobben er ferdig kjørt, men beholde resten av endringene og slå dem sammen med branchen som leser fra hist-topicen. 