### PR TITLE
Aktuell status fra arena skal konverteres til Ikke aktuell

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
@@ -5,7 +5,7 @@ import no.nav.amt.arena.acl.processors.converters.ArenaDeltakerAarsakConverter
 import no.nav.amt.arena.acl.processors.converters.ArenaDeltakerStatusConverter
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.*
+import java.util.UUID
 
 data class TiltakDeltaker(
 	val tiltakdeltakerId: String,
@@ -54,6 +54,7 @@ data class TiltakDeltaker(
 		gjennomforingId: UUID,
 		gjennomforingSluttDato: LocalDate?,
 		erGjennomforingAvsluttet: Boolean,
+		tiltakstype: String,
 		personIdent: String,
 		erKurs: Boolean
 	): AmtDeltaker {
@@ -65,6 +66,7 @@ data class TiltakDeltaker(
 			datoStatusEndring = datoStatusendring,
 			gjennomforingSluttdato = gjennomforingSluttDato,
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			tiltakstype = tiltakstype,
 			erKurs = erKurs
 		).convert()
 		val statusAarsak = ArenaDeltakerAarsakConverter.convert(

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -160,6 +160,7 @@ open class DeltakerProcessor(
 			gjennomforingId = gjennomforing.id,
 			gjennomforingSluttDato = gjennomforing.sluttDato,
 			erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
+			tiltakstype = gjennomforing.tiltakstype.arenaKode,
 			erKurs = gjennomforing.erKurs(),
 			personIdent = personIdent,
 		)

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
@@ -86,6 +86,7 @@ open class HistDeltakerProcessor(
 			gjennomforingId = gjennomforing.id,
 			gjennomforingSluttDato = gjennomforing.sluttDato,
 			erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
+			tiltakstype = gjennomforing.tiltakstype.arenaKode,
 			erKurs = gjennomforing.erKurs(),
 			personIdent = personIdent,
 		)

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/converters/ArenaDeltakerStatusConverter.kt
@@ -15,12 +15,13 @@ class ArenaDeltakerStatusConverter(
 	val datoStatusEndring: LocalDateTime?,
 	val erGjennomforingAvsluttet: Boolean,
 	val gjennomforingSluttdato: LocalDate?,
-	val erKurs: Boolean
+	val erKurs: Boolean,
+	val tiltakstype: String
 ) {
 
 	fun convert(): DeltakerStatus {
 		val status =
-			if (arenaStatus.erUgyldigForInntakstype()) DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, LocalDateTime.now())
+			if (arenaStatus.erUgyldigForTiltaksstype()) DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, LocalDateTime.now())
 			else if (arenaStatus.erSoktInn()) utledSoktInnStatus()
 			else if (arenaStatus.erFeilregistrert()) utledFeilregistrertStatus()
 			else if (erKurs) convertKursStatuser()
@@ -163,8 +164,8 @@ class ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.INFOMOETE
 		)
 	}
-	private fun TiltakDeltaker.Status.erUgyldigForInntakstype(): Boolean {
-		return this == TiltakDeltaker.Status.AKTUELL && !erKurs
+	private fun TiltakDeltaker.Status.erUgyldigForTiltaksstype(): Boolean {
+		return this == TiltakDeltaker.Status.AKTUELL && tiltakstype == "ARBFORB"
 	}
 
 	private fun TiltakDeltaker.Status.erFeilregistrert(): Boolean {

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
@@ -23,21 +23,23 @@ private val now = LocalDateTime.now()
 
 class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	val erGjennomforingAvsluttet = false
+	val INDOPPFAG = "INDOPPFAG"
+	val GRUPPEAMO = "GRUPPEAMO"
 
 	"status - AKTUELL - kurs - returnerer SOKT_INN" {
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), true).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), true, GRUPPEAMO).convert()
 
 		status.navn shouldBe SOKT_INN
 	}
 
-	"status - AKTUELL - ikke kurs - returnerer SOKT_INN" {
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+	"status - AKTUELL - ARBFORB - returnerer SOKT_INN" {
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false, "ARBFORB").convert()
 
 		status.navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - FEILREG - returnerer FEILREGISTRERT" {
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FEILREG, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FEILREG, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 
 		status.navn shouldBe FEILREGISTRERT
 	}
@@ -49,7 +51,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
@@ -60,29 +62,29 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - DELAVB og har startdato før endretdato - returnerer HAR_SLUTTET" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.DELAVB, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe HAR_SLUTTET
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.DELAVB, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe HAR_SLUTTET
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.DELAVB,
 			now,
 			yesterday.minusDays(1),
 			null,
 			yesterday.atStartOfDay(),
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG,
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - DELAVB og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.DELAVB, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe IKKE_AKTUELL
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.DELAVB, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe IKKE_AKTUELL
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.DELAVB,
 			now,
 			yesterday,
 			null,
 			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - DELAVB og har startdato i fremtid - returnerer IKKE_AKTUELL" {
@@ -92,7 +94,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
@@ -103,19 +105,19 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - FULLF og har startdato før endretdato - returnerer HAR_SLUTTET" {
 		val endretDato = yesterday.atTime(13, 30)
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FULLF, now, endretDato.minusDays(1).toLocalDate(), null, endretDato, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FULLF, now, endretDato.minusDays(1).toLocalDate(), null, endretDato, erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 		status.navn shouldBe HAR_SLUTTET
 		status.endretDato shouldBe endretDato
 	}
 	"status - FULLF og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
 		val endretDato = yesterday.minusDays(1).atTime(13, 30)
 
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FULLF, now, yesterday, null, endretDato, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.FULLF, now, yesterday, null, endretDato, erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 
 		status.navn shouldBe IKKE_AKTUELL
 		status.endretDato shouldBe endretDato
@@ -127,7 +129,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
@@ -141,7 +143,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = sluttDato,
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now(),
-			false
+			false,
+			INDOPPFAG
 		).convert()
 		status.navn shouldBe HAR_SLUTTET
 	}
@@ -153,18 +156,18 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - GJENN og har startdato i fortid - returnerer GJENNOMFORES" {
 		val startDato = yesterday.minusDays(1)
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, startDato, null, startDato.plusDays(1).atTime(12, 30), erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, startDato, null, startDato.plusDays(1).atTime(12, 30), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 		status.navn shouldBe DELTAR
 		status.endretDato shouldBe startDato.atStartOfDay()
 	}
 	"status - GJENN og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
 		val datoEndret = tomorrow.atTime(10,30)
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, datoEndret.plusDays(2).toLocalDate(), null, datoEndret, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, datoEndret.plusDays(2).toLocalDate(), null, datoEndret, erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 		status.navn shouldBe VENTER_PA_OPPSTART
 		status.endretDato shouldBe datoEndret
 	}
@@ -175,12 +178,12 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday.minusDays(1),
 			yesterday,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN og har sluttdato i fremtid - returnerer GJENNOMFORES" {
 		val startDato = yesterday
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, startDato, tomorrow.plusDays(1), tomorrow.atTime(10, 20), erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN, now, startDato, tomorrow.plusDays(1), tomorrow.atTime(10, 20), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 		status.navn shouldBe DELTAR
 		status.endretDato shouldBe startDato.atStartOfDay()
 	}
@@ -192,7 +195,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			sluttDato.minusDays(1),
 			sluttDato,
 			sluttDato.plusDays(1).atTime(10, 20),
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert()
 		status.navn shouldBe HAR_SLUTTET
 		status.endretDato shouldBe sluttDato.atStartOfDay()
@@ -206,14 +209,14 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVB og har startdato før endretdato - returnerer HAR_SLUTTET" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVB, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe HAR_SLUTTET
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVB, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN_AVB og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVB, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe IKKE_AKTUELL
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVB, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVB og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
@@ -222,7 +225,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og mangler startdato - returnerer IKKE_AKTUELL" {
@@ -232,14 +235,14 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og har startdato før endretdato - returnerer HAR_SLUTTET" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVL, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe HAR_SLUTTET
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVL, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN_AVL og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVL, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe IKKE_AKTUELL
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.GJENN_AVL, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
@@ -248,19 +251,19 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - IKKAKTUELL - returnerer IKKE_AKTUELL" {
 		val statusEndret = yesterday.minusDays(5)
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKAKTUELL, now, statusEndret.plusDays(2), statusEndret.plusDays(4), statusEndret.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKAKTUELL, now, statusEndret.plusDays(2), statusEndret.plusDays(4), statusEndret.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert()
 		status.navn shouldBe IKKE_AKTUELL
 		status.endretDato shouldBe statusEndret.atStartOfDay()
 	}
 
 	"status - IKKAKTUELL - returnerer FEILREGISTRERT hvis registrert dato er samme dag som status endring" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKAKTUELL, now, null, null, now, erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe FEILREGISTRERT
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKAKTUELL, now, null, null, now, erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe FEILREGISTRERT
 	}
 
 	"status - IKKEM og mangler startdato - returnerer IKKE_AKTUELL" {
@@ -270,14 +273,14 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - IKKEM og har startdato før endretdato - returnerer HAR_SLUTTET" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKEM, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe HAR_SLUTTET
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKEM, now, yesterday.minusDays(1), null, yesterday.atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - IKKEM og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
-		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKEM, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false).convert().navn shouldBe IKKE_AKTUELL
+		ArenaDeltakerStatusConverter(TiltakDeltaker.Status.IKKEM, now, yesterday, null, yesterday.minusDays(1).atStartOfDay(), erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - IKKEM og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
@@ -286,7 +289,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - INFOMOETE - returnerer VURDERES" {
@@ -296,7 +299,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VURDERES
 	}
 	"status - JATAKK - returnerer VENTER_PÅ_OPPSTART" {
@@ -306,7 +309,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - JATAKK og har startdato i fortid - returnerer GJENNOMFORES" {
@@ -316,7 +319,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe DELTAR
 	}
 	"status - JATAKK og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
@@ -326,7 +329,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - JATAKK og har sluttdato i fortid - returnerer HAR_SLUTTET" {
@@ -336,7 +339,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday.minusDays(1),
 			yesterday,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - JATAKK og har sluttdato i fremtid - returnerer GJENNOMFORES" {
@@ -346,7 +349,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday,
 			tomorrow,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe DELTAR
 	}
 	"status - NEITAKK - returnerer IKKE_AKTUELL" {
@@ -356,7 +359,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - TILBUD - returnerer VENTER_PÅ_OPPSTART" {
@@ -366,7 +369,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - TILBUD og har startdato i fortid - returnerer GJENNOMFORES" {
@@ -376,7 +379,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe DELTAR
 	}
 	"status - TILBUD og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
@@ -386,7 +389,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			tomorrow,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - TILBUD og har sluttdato i fortid - returnerer HAR_SLUTTET" {
@@ -396,7 +399,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday.minusDays(1),
 			yesterday,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - TILBUD og har sluttdato i fremtid - returnerer GJENNOMFORES" {
@@ -406,7 +409,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday,
 			tomorrow,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe DELTAR
 	}
 	"status - VENTELISTE - returnerer VENTELISTE" {
@@ -416,7 +419,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			null,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(), false, INDOPPFAG
 		).convert().navn shouldBe VENTELISTE
 	}
 
@@ -427,7 +430,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			LocalDate.now(),
 			null,
 			LocalDateTime.now(),
-			erGjennomforingAvsluttet, LocalDate.now(), true
+			erGjennomforingAvsluttet, LocalDate.now(), true, GRUPPEAMO
 		).convert().navn shouldBe VENTELISTE
 	}
 
@@ -438,7 +441,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			LocalDate.now(),
 			null,
 			LocalDateTime.now(),
-			erGjennomforingAvsluttet, LocalDate.now(), true
+			erGjennomforingAvsluttet, LocalDate.now(), true, GRUPPEAMO
 		).convert().navn shouldBe SOKT_INN
 	}
 
@@ -452,7 +455,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().minusDays(5),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now(),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe AVBRUTT
 	}
 
@@ -466,7 +470,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().minusDays(5),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().minusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe FULLFORT
 	}
 
@@ -479,7 +484,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now(),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 
@@ -492,7 +498,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(3),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe FULLFORT
 	}
 
@@ -505,7 +512,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe FULLFORT
 	}
 
@@ -518,7 +526,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe AVBRUTT
 	}
 
@@ -531,7 +540,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe AVBRUTT
 	}
 
@@ -544,7 +554,8 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(1),
 			erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(1),
-			true
+			true,
+			GRUPPEAMO
 		).convert().navn shouldBe FULLFORT
 	}
 })

--- a/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/processors/DeltakerStatusConverterTest.kt
@@ -2,7 +2,16 @@ package no.nav.amt.arena.acl.processors
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
-import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.*
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.AVBRUTT
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.DELTAR
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.FEILREGISTRERT
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.FULLFORT
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.HAR_SLUTTET
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.IKKE_AKTUELL
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.SOKT_INN
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.VENTELISTE
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.VENTER_PA_OPPSTART
+import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.VURDERES
 import no.nav.amt.arena.acl.domain.kafka.arena.TiltakDeltaker
 import no.nav.amt.arena.acl.processors.converters.ArenaDeltakerStatusConverter
 import java.time.LocalDate
@@ -15,10 +24,16 @@ private val now = LocalDateTime.now()
 class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	val erGjennomforingAvsluttet = false
 
-	"status - AKTUELL - returnerer SOKT_INN" {
-		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+	"status - AKTUELL - kurs - returnerer SOKT_INN" {
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), true).convert()
 
 		status.navn shouldBe SOKT_INN
+	}
+
+	"status - AKTUELL - ikke kurs - returnerer SOKT_INN" {
+		val status = ArenaDeltakerStatusConverter(TiltakDeltaker.Status.AKTUELL, now, null, null, null, erGjennomforingAvsluttet, LocalDate.now(), false).convert()
+
+		status.navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - FEILREG - returnerer FEILREGISTRERT" {


### PR DESCRIPTION
https://trello.com/c/2PARcBCY/1791-aft-deltakere-med-arenastatus-aktuell-skal-f%C3%A5-ny-status-ikke-aktuell

Avklare: Leser arena data fra topicen i prod? 
Isåfall må vi kanskje vente med å relaste der siden fylkene har fått beskjed om at dette skjer ved lansering av ny løsning