### PR TITLE
Innfører ny status for arena data for å håndtere lagring av deltakere med kildesystem komet

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/db/ArenaDataDbo.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/db/ArenaDataDbo.kt
@@ -10,7 +10,8 @@ enum class IngestStatus {
 	FAILED,
 	IGNORED,
 	INVALID,
-	WAITING
+	WAITING,
+	EXTERNAL_SOURCE
 }
 
 data class ArenaDataDbo(

--- a/src/main/kotlin/no/nav/amt/arena/acl/exceptions/ExternalSourceSystemException.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/exceptions/ExternalSourceSystemException.kt
@@ -1,0 +1,3 @@
+package no.nav.amt.arena.acl.exceptions
+
+class ExternalSourceSystemException(message: String) : Exception(message)

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -14,6 +14,7 @@ import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltaker
 import no.nav.amt.arena.acl.domain.kafka.arena.ArenaDeltakerKafkaMessage
 import no.nav.amt.arena.acl.exceptions.DependencyNotIngestedException
 import no.nav.amt.arena.acl.exceptions.DependencyNotValidException
+import no.nav.amt.arena.acl.exceptions.ExternalSourceSystemException
 import no.nav.amt.arena.acl.exceptions.IgnoredException
 import no.nav.amt.arena.acl.exceptions.ValidationException
 import no.nav.amt.arena.acl.metrics.DeltakerMetricHandler
@@ -46,17 +47,16 @@ open class DeltakerProcessor(
 		val arenaDeltakerRaw = message.getData()
 		val arenaDeltakerId = arenaDeltakerRaw.TILTAKDELTAKER_ID.toString()
 		val arenaGjennomforingId = arenaDeltakerRaw.TILTAKGJENNOMFORING_ID.toString()
+		val gjennomforing = getGjennomforing(arenaGjennomforingId)
 
 		if (!arenaDeltakerRaw.EKSTERN_ID.isNullOrEmpty()) {
-			throw IgnoredException("Ignorerer deltaker som har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
+			throw ExternalSourceSystemException("Ignorerer deltaker som har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
 		}
 		if (arenaDeltakerRaw.DELTAKERTYPEKODE == "EKSTERN") {
-			throw IgnoredException("Ignorerer deltaker som har deltakertypekode ekstern, arenaid $arenaDeltakerId")
+			throw ExternalSourceSystemException("Ignorerer deltaker som har deltakertypekode ekstern, arenaid $arenaDeltakerId")
 		}
 
-		val gjennomforing = getGjennomforing(arenaGjennomforingId)
 		val deltaker = createDeltaker(arenaDeltakerRaw, gjennomforing)
-
 		val deltakerData = arenaDataRepository.get(ARENA_DELTAKER_TABLE_NAME, arenaDeltakerId)
 
 		if (skalRetryes(deltakerData, message)) {

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -50,10 +50,10 @@ open class DeltakerProcessor(
 		val gjennomforing = getGjennomforing(arenaGjennomforingId)
 
 		if (!arenaDeltakerRaw.EKSTERN_ID.isNullOrEmpty()) {
-			throw ExternalSourceSystemException("Ignorerer deltaker som har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
+			throw ExternalSourceSystemException("Deltaker har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
 		}
 		if (arenaDeltakerRaw.DELTAKERTYPEKODE == "EKSTERN") {
-			throw ExternalSourceSystemException("Ignorerer deltaker som har deltakertypekode ekstern, arenaid $arenaDeltakerId")
+			throw ExternalSourceSystemException("Deltaker har deltakertypekode ekstern, arenaid $arenaDeltakerId")
 		}
 
 		val deltaker = createDeltaker(arenaDeltakerRaw, gjennomforing)

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
@@ -42,10 +42,10 @@ open class HistDeltakerProcessor(
 		val gjennomforing = deltakerProcessor.getGjennomforing(arenaGjennomforingId)
 
 		if (!arenaDeltakerRaw.EKSTERN_ID.isNullOrEmpty()) {
-			throw ExternalSourceSystemException("Ignorerer hist-deltaker som har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
+			throw ExternalSourceSystemException("hist-deltaker har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")
 		}
 		if (arenaDeltakerRaw.DELTAKERTYPEKODE == "EKSTERN") {
-			throw ExternalSourceSystemException("Ignorerer hist-deltaker som har deltakertypekode ekstern, arenaid $arenaDeltakerId")
+			throw ExternalSourceSystemException("hist-deltaker har deltakertypekode ekstern, arenaid $arenaDeltakerId")
 		}
 
 		if (message.operationType != AmtOperation.CREATED) {


### PR DESCRIPTION
Endrer også rekkefølge på eksekvering for å unngå lagring av tiltakstyper som vi ikke skal eie
https://trello.com/c/iLLhZ9T9/1807-meldinger-med-eksternid-fra-arena-skal-ha-en-annen-status-enn-ignored-slik-at-de-ikke-slettes