### PR TITLE
Lagrer id mapping på eksterne kometdeltakere

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/controller/Controller.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/controller/Controller.kt
@@ -19,7 +19,7 @@ class Controller(
 	@ProtectedWithClaims(issuer = Issuer.AZURE_AD)
 	@GetMapping("/translation/{id}")
 	fun hentArenaId(@PathVariable("id") id: UUID): HentArenaIdResponse {
-		return arenaDataIdTranslationService.hentArenaId(id)
+		return arenaDataIdTranslationService.hentArenaIdEllerHistId(id)
 			?.let { HentArenaIdResponse(it) }
 			?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Fant ikke arena id for $id")
 	}

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -75,7 +75,7 @@ open class DeltakerProcessor(
 		if (!arenaDeltakerRaw.EKSTERN_ID.isNullOrEmpty()) {
 			val eksternId = UUID.fromString(arenaDeltakerRaw.EKSTERN_ID)
 
-			val arenaId = arenaDataIdTranslationService.hentArenaId(UUID.fromString(arenaDeltakerRaw.EKSTERN_ID))
+			val arenaId = arenaDataIdTranslationService.hentArenaId(eksternId)
 			if (arenaId == null) {
 				arenaDataIdTranslationService.opprettIdTranslation(arenaDeltakerId, eksternId)
 			}

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/HistDeltakerProcessor.kt
@@ -82,7 +82,7 @@ open class HistDeltakerProcessor(
 				arenaDataIdTranslationService.lagreHistDeltakerId(amtDeltakerId = eksternId, histDeltakerArenaId = deltakerHistId)
 			}
 			else if (arenaId != deltakerHistId) {
-				throw ValidationException("Fikk arenadeltaker med id $deltakerHistId og EKSTERN_ID ${arenaDeltakerRaw.EKSTERN_ID} men arenaId er allerede mappet til $arenaId")
+				throw ValidationException("Fikk arena hist-deltaker med id $deltakerHistId og EKSTERN_ID ${arenaDeltakerRaw.EKSTERN_ID} men arenaId er allerede mappet til $arenaId")
 			}
 
 			throw ExternalSourceSystemException("hist-deltaker har eksternid ${arenaDeltakerRaw.EKSTERN_ID}")

--- a/src/main/kotlin/no/nav/amt/arena/acl/services/ArenaDataIdTranslationService.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/services/ArenaDataIdTranslationService.kt
@@ -17,7 +17,7 @@ open class ArenaDataIdTranslationService(
 
 	private val log = LoggerFactory.getLogger(javaClass)
 
-	fun hentArenaId(id: UUID): String? {
+	fun hentArenaIdEllerHistId(id: UUID): String? {
 		return arenaDataIdTranslationRepository.get(id)?.arenaId
 			?: arenaDataHistIdTranslationRepository.get(id)?.arenaHistId
 	}
@@ -26,24 +26,39 @@ open class ArenaDataIdTranslationService(
 		return arenaDataHistIdTranslationRepository.get(id)?.arenaHistId
 	}
 
+	fun hentArenaId(id: UUID): String? {
+		return arenaDataIdTranslationRepository.get(id)?.arenaId
+	}
+
 	fun hentEllerOpprettNyDeltakerId(deltakerArenaId: String): UUID {
 		val deltakerId = arenaDataIdTranslationRepository.get(ARENA_DELTAKER_TABLE_NAME, deltakerArenaId)?.amtId
 
 		if (deltakerId == null) {
-			val nyDeltakerIdId = UUID.randomUUID()
+			val nyDeltakerId = UUID.randomUUID()
 			arenaDataIdTranslationRepository.insert(
 				ArenaDataIdTranslationDbo(
-					amtId = nyDeltakerIdId,
+					amtId = nyDeltakerId,
 					arenaTableName = ARENA_DELTAKER_TABLE_NAME,
 					arenaId = deltakerArenaId
 				)
 			)
 
-			log.info("Opprettet ny id for deltaker, id=$nyDeltakerIdId arenaId=$deltakerArenaId")
-			return nyDeltakerIdId
+			log.info("Opprettet ny id for deltaker, id=$nyDeltakerId arenaId=$deltakerArenaId")
+			return nyDeltakerId
 		}
 
 		return deltakerId
+	}
+
+	fun opprettIdTranslation(arenaId: String, amtId: UUID) {
+		arenaDataIdTranslationRepository.insert(
+			ArenaDataIdTranslationDbo(
+			amtId = amtId,
+			arenaTableName = ARENA_DELTAKER_TABLE_NAME,
+			arenaId = arenaId
+		))
+		log.info("Opprettet ny id for deltaker, id=$amtId arenaId=$arenaId")
+
 	}
 
 	fun lagreHistDeltakerId(

--- a/src/test/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataIdTranslationRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/repositories/ArenaDataIdTranslationRepositoryTest.kt
@@ -10,7 +10,7 @@ import no.nav.amt.arena.acl.database.SingletonPostgresContainer
 import no.nav.amt.arena.acl.domain.db.ArenaDataIdTranslationDbo
 import org.slf4j.LoggerFactory
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import java.util.*
+import java.util.UUID
 
 class ArenaDataIdTranslationRepositoryTest : FunSpec({
 


### PR DESCRIPTION
Lagrer arenaid i mapping uavhengig av kildesystem, for lettere feilsøking