### PR TITLE
Lagre strukturerte data om arenadeltakere for å kunne matche hist del…

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/ArenaDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/ArenaDeltaker.kt
@@ -1,11 +1,14 @@
 package no.nav.amt.arena.acl.domain.kafka.arena
 
 import no.nav.amt.arena.acl.exceptions.ValidationException
+import no.nav.amt.arena.acl.repositories.DeltakerInsertDbo
+import no.nav.amt.arena.acl.utils.ARENA_DELTAKER_TABLE_NAME
 import no.nav.amt.arena.acl.utils.asValidatedLocalDate
 import no.nav.amt.arena.acl.utils.asValidatedLocalDateTime
 import org.slf4j.LoggerFactory
 import java.time.LocalDateTime
 import java.time.Month
+import java.util.UUID
 
 // @SONAR_START@
 data class ArenaDeltaker(
@@ -45,7 +48,7 @@ data class ArenaDeltaker(
 
 	private val log = LoggerFactory.getLogger(javaClass)
 
-	private val placeholderDate = LocalDateTime.of(1970, Month.JANUARY, 1, 0,0)
+	private val placeholderDate = LocalDateTime.of(1970, Month.JANUARY, 1, 0, 0)
 
 	fun mapTiltakDeltaker(): TiltakDeltaker {
 		val tiltakdeltakerId = TILTAKDELTAKER_ID.toString().also {
@@ -57,8 +60,8 @@ data class ArenaDeltaker(
 		}
 
 		val regDato = REG_DATO?.asValidatedLocalDateTime("REG_DATO") ?: placeholderDate.also {
-				log.warn("Bruker med arenaId=${tiltakdeltakerId} mangler REG_DATO, bruker placeholder dato istedenfor")
-			}
+			log.warn("Bruker med arenaId=${tiltakdeltakerId} mangler REG_DATO, bruker placeholder dato istedenfor")
+		}
 
 
 		return TiltakDeltaker(
@@ -69,7 +72,7 @@ data class ArenaDeltaker(
 			datoTil = DATO_TIL?.asValidatedLocalDate("DATO_TIL"),
 			deltakerStatusKode = TiltakDeltaker.Status.valueOf(DELTAKERSTATUSKODE),
 			datoStatusendring = DATO_STATUSENDRING?.asValidatedLocalDateTime("DATO_STATUSENDRING"),
-			statusAarsakKode = AARSAKVERDIKODE_STATUS?.let {TiltakDeltaker.StatusAarsak.valueOf(AARSAKVERDIKODE_STATUS)},
+			statusAarsakKode = AARSAKVERDIKODE_STATUS?.let { TiltakDeltaker.StatusAarsak.valueOf(AARSAKVERDIKODE_STATUS) },
 			dagerPerUke = ANTALL_DAGER_PR_UKE,
 			prosentDeltid = PROSENT_DELTID,
 			regDato = regDato,
@@ -79,6 +82,20 @@ data class ArenaDeltaker(
 			innsokBegrunnelse = BEGRUNNELSE_BESTILLING ?: ""
 		)
 	}
+
+	fun toDbo() = DeltakerInsertDbo(
+		arenaId = TILTAKDELTAKER_ID,
+		personId = PERSON_ID,
+		gjennomforingId = TILTAKGJENNOMFORING_ID,
+		datoFra = DATO_FRA?.asValidatedLocalDate("DATO_FRA"),
+		datoTil = DATO_TIL?.asValidatedLocalDate("DATO_TIL"),
+		regDato = REG_DATO?.asValidatedLocalDateTime("REG_DATO"),
+		modDato = MOD_DATO?.asValidatedLocalDateTime("MOD_DATO"),
+		status = DELTAKERSTATUSKODE,
+		datoStatusEndring = DATO_STATUSENDRING?.asValidatedLocalDateTime("DATO_STATUSENDRING"),
+		arenaSourceTable = ARENA_DELTAKER_TABLE_NAME,
+		eksternId = UUID.fromString(EKSTERN_ID),
+	)
 
 }
 // @SONAR_STOP@

--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/ArenaDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/ArenaDeltaker.kt
@@ -94,7 +94,7 @@ data class ArenaDeltaker(
 		status = DELTAKERSTATUSKODE,
 		datoStatusEndring = DATO_STATUSENDRING?.asValidatedLocalDateTime("DATO_STATUSENDRING"),
 		arenaSourceTable = ARENA_DELTAKER_TABLE_NAME,
-		eksternId = UUID.fromString(EKSTERN_ID),
+		eksternId = EKSTERN_ID?.let { UUID.fromString(EKSTERN_ID)},
 	)
 
 }

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -63,15 +63,18 @@ open class DeltakerProcessor(
 		if (skalVente(deltakerData)) {
 			Thread.sleep(500)
 		}
+		log.info("Prosesserer melding for deltaker id=${deltaker.id} arenaId=$arenaDeltakerId op=${message.operationType} er sendt")
 
 		if (message.operationType == AmtOperation.DELETED) {
 			handleDeleteMessage(deltaker, arenaDeltakerId, message, deltakerData)
 		} else {
 			sendMessageAndUpdateIngestStatus(message, deltaker, arenaDeltakerId)
+			log.info("Lagrer deltaker med id=${deltaker.id}")
 			deltakerRepository.upsert(arenaDeltakerRaw.toDbo())
 
 		}
 		metrics.publishMetrics(message)
+		log.info("Deltaker med id=${deltaker.id} ferdig prosessert")
 	}
 
 	private fun externalDeltakerGuard(arenaDeltakerRaw: ArenaDeltaker) {

--- a/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/processors/DeltakerProcessor.kt
@@ -19,6 +19,7 @@ import no.nav.amt.arena.acl.exceptions.IgnoredException
 import no.nav.amt.arena.acl.exceptions.ValidationException
 import no.nav.amt.arena.acl.metrics.DeltakerMetricHandler
 import no.nav.amt.arena.acl.repositories.ArenaDataRepository
+import no.nav.amt.arena.acl.repositories.DeltakerRepository
 import no.nav.amt.arena.acl.services.ArenaDataIdTranslationService
 import no.nav.amt.arena.acl.services.GjennomforingService
 import no.nav.amt.arena.acl.services.KafkaProducerService
@@ -33,6 +34,7 @@ import java.util.UUID
 @Component
 open class DeltakerProcessor(
 	private val arenaDataRepository: ArenaDataRepository,
+	private val deltakerRepository: DeltakerRepository,
 	private val gjennomforingService: GjennomforingService,
 	private val arenaDataIdTranslationService: ArenaDataIdTranslationService,
 	private val ordsClient: ArenaOrdsProxyClient,
@@ -66,6 +68,8 @@ open class DeltakerProcessor(
 			handleDeleteMessage(deltaker, arenaDeltakerId, message, deltakerData)
 		} else {
 			sendMessageAndUpdateIngestStatus(message, deltaker, arenaDeltakerId)
+			deltakerRepository.upsert(arenaDeltakerRaw.toDbo())
+
 		}
 		metrics.publishMetrics(message)
 	}

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerDbo.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerDbo.kt
@@ -1,0 +1,22 @@
+package no.nav.amt.arena.acl.repositories
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class DeltakerDbo(
+	val id: UUID,
+	val arenaId: Long?,
+	val personId: Long?,
+	val gjennomforingId: Long?,
+	val datoFra: LocalDate?,
+	val datoTil: LocalDate?,
+	val regDato: LocalDateTime,
+	val modDato: LocalDateTime?,
+	val status: String?,
+	val datoStatusEndring: LocalDateTime,
+	val arenaSourceTable: String,
+	val eksternId: UUID,
+	val createdAt: LocalDateTime,
+	val modifiedAt: LocalDateTime,
+)

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerInsertDbo.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerInsertDbo.kt
@@ -1,0 +1,19 @@
+package no.nav.amt.arena.acl.repositories
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class DeltakerInsertDbo(
+	val arenaId: Long?,
+	val personId: Long?,
+	val gjennomforingId: Long?,
+	val datoFra: LocalDate?,
+	val datoTil: LocalDate?,
+	val regDato: LocalDateTime?,
+	val modDato: LocalDateTime?,
+	val status: String?,
+	val datoStatusEndring: LocalDateTime?,
+	val arenaSourceTable: String,
+	val eksternId: UUID,
+)

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerInsertDbo.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerInsertDbo.kt
@@ -15,5 +15,5 @@ data class DeltakerInsertDbo(
 	val status: String?,
 	val datoStatusEndring: LocalDateTime?,
 	val arenaSourceTable: String,
-	val eksternId: UUID,
+	val eksternId: UUID?,
 )

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepository.kt
@@ -61,7 +61,6 @@ class DeltakerRepository(
 				:eksternId,
 				:arenaSourceTable
 			) ON CONFLICT(arena_id, arena_source_table) DO UPDATE SET
-				arena_id = :arenaId,
 				person_id = :personId,
 				gjennomforing_id = :gjennomforingId,
 				dato_fra = :datoFra,
@@ -71,7 +70,6 @@ class DeltakerRepository(
 				status = :status,
 				dato_statusendring = :datoStatusEndring,
 				ekstern_id = :eksternId,
-				arena_source_table = :arenaSourceTable,
 				modified_at = CURRENT_TIMESTAMP
 		""".trimIndent()
 		val parameters = sqlParameters(
@@ -85,8 +83,8 @@ class DeltakerRepository(
 			"modDato" to deltakerDbo.modDato,
 			"status" to deltakerDbo.status,
 			"datoStatusEndring" to deltakerDbo.datoStatusEndring,
-			"eksternId" to deltakerDbo.eksternId,
 			"arenaSourceTable" to deltakerDbo.arenaSourceTable,
+			"eksternId" to deltakerDbo.eksternId,
 		)
 		template.update(sql, parameters)
 	}

--- a/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepository.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepository.kt
@@ -1,0 +1,105 @@
+package no.nav.amt.arena.acl.repositories
+
+import no.nav.amt.arena.acl.utils.DatabaseUtils.sqlParameters
+import no.nav.amt.arena.acl.utils.getLocalDate
+import no.nav.amt.arena.acl.utils.getLocalDateTime
+import no.nav.amt.arena.acl.utils.getUUID
+import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+@Component
+class DeltakerRepository(
+	private val template: NamedParameterJdbcTemplate,
+) {
+	private val rowMapper = RowMapper { rs, _ ->
+		DeltakerDbo(
+			id = rs.getUUID("id"),
+			arenaId = rs.getLong("arena_id"),
+			personId = rs.getLong("person_id"),
+			gjennomforingId = rs.getLong("gjennomforing_id"),
+			datoFra = rs.getLocalDate("dato_fra"),
+			datoTil = rs.getLocalDate("dato_til"),
+			regDato = rs.getLocalDateTime("reg_dato"),
+			modDato = rs.getLocalDateTime("mod_dato"),
+			status = rs.getString("status"),
+			datoStatusEndring = rs.getLocalDateTime("dato_statusendring"),
+			eksternId = rs.getUUID("ekstern_id"),
+			arenaSourceTable = rs.getString("arena_source_table"),
+			createdAt = rs.getLocalDateTime("created_at"),
+			modifiedAt = rs.getLocalDateTime("modified_at")
+		)
+	}
+
+	fun upsert(deltakerDbo: DeltakerInsertDbo) {
+		val sql = """
+			INSERT INTO deltaker(
+				id,
+				arena_id,
+				person_id,
+				gjennomforing_id,
+				dato_fra,
+				dato_til,
+				reg_dato,
+				mod_dato,
+				status,
+				dato_statusendring,
+				ekstern_id,
+				arena_source_table)
+			VALUES (
+				:id,
+				:arenaId,
+				:personId,
+				:gjennomforingId,
+				:datoFra,
+				:datoTil,
+				:regDato,
+				:modDato,
+				:status,
+				:datoStatusEndring,
+				:eksternId,
+				:arenaSourceTable
+			) ON CONFLICT(arena_id, arena_source_table) DO UPDATE SET
+				arena_id = :arenaId,
+				person_id = :personId,
+				gjennomforing_id = :gjennomforingId,
+				dato_fra = :datoFra,
+				dato_til = :datoTil,
+				reg_dato = :regDato,
+				mod_dato = :modDato,
+				status = :status,
+				dato_statusendring = :datoStatusEndring,
+				ekstern_id = :eksternId,
+				arena_source_table = :arenaSourceTable,
+				modified_at = CURRENT_TIMESTAMP
+		""".trimIndent()
+		val parameters = sqlParameters(
+			"id" to UUID.randomUUID(),
+			"arenaId" to deltakerDbo.arenaId,
+			"personId" to deltakerDbo.personId,
+			"gjennomforingId" to deltakerDbo.gjennomforingId,
+			"datoFra" to deltakerDbo.datoFra,
+			"datoTil" to deltakerDbo.datoTil,
+			"regDato" to deltakerDbo.regDato,
+			"modDato" to deltakerDbo.modDato,
+			"status" to deltakerDbo.status,
+			"datoStatusEndring" to deltakerDbo.datoStatusEndring,
+			"eksternId" to deltakerDbo.eksternId,
+			"arenaSourceTable" to deltakerDbo.arenaSourceTable,
+		)
+		template.update(sql, parameters)
+	}
+
+	fun get(arenaId: Long, arenaTable: String): DeltakerDbo? {
+		val sql = "SELECT * FROM deltaker WHERE arena_id = :arenaId AND arena_source_table = :arenaTable"
+		val parameters = sqlParameters(
+			"arenaId" to arenaId,
+			"arenaTable" to arenaTable,
+		)
+		return template.query(sql, parameters, rowMapper).firstOrNull()
+	}
+
+
+
+}

--- a/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
@@ -4,6 +4,7 @@ import no.nav.amt.arena.acl.domain.db.ArenaDataDbo
 import no.nav.amt.arena.acl.domain.db.IngestStatus
 import no.nav.amt.arena.acl.domain.kafka.arena.ArenaKafkaMessage
 import no.nav.amt.arena.acl.exceptions.DependencyNotValidException
+import no.nav.amt.arena.acl.exceptions.ExternalSourceSystemException
 import no.nav.amt.arena.acl.exceptions.IgnoredException
 import no.nav.amt.arena.acl.processors.DeltakerProcessor
 import no.nav.amt.arena.acl.processors.GjennomforingProcessor
@@ -82,6 +83,10 @@ open class RetryArenaMessageProcessorService(
 			if (e is IgnoredException) {
 				log.info("${arenaDataDbo.id} in table ${arenaDataDbo.arenaTableName}: '${e.message}'")
 				arenaDataRepository.updateIngestStatus(arenaDataDbo.id, IngestStatus.IGNORED)
+			}
+			if (e is ExternalSourceSystemException) {
+				log.info("${arenaDataDbo.id} in table ${arenaDataDbo.arenaTableName} was created by a external source system: '${e.message}'")
+				arenaDataRepository.updateIngestStatus(arenaDataDbo.id, IngestStatus.EXTERNAL_SOURCE)
 			}
 			else if (e is DependencyNotValidException) {
 				log.error("${arenaDataDbo.id} in table ${arenaDataDbo.arenaTableName}: '${e.message}'")

--- a/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/services/RetryArenaMessageProcessorService.kt
@@ -95,7 +95,7 @@ open class RetryArenaMessageProcessorService(
 			else if (arenaDataDbo.ingestStatus == IngestStatus.RETRY && hasReachedMaxRetries) {
 				arenaDataRepository.updateIngestStatus(arenaDataDbo.id, IngestStatus.FAILED)
 			}
-			else log.error("${arenaDataDbo.id} in table ${arenaDataDbo.arenaTableName}: '${e.message}'")
+			else log.error("${arenaDataDbo.id} in table ${arenaDataDbo.arenaTableName}: '${e.message}', '${e.stackTrace}'")
 
 
 			arenaDataRepository.updateIngestAttempts(arenaDataDbo.id, currentIngestAttempts, e.message)

--- a/src/main/resources/db/migration/V17__table_deltaker.sql
+++ b/src/main/resources/db/migration/V17__table_deltaker.sql
@@ -1,0 +1,19 @@
+CREATE TABLE deltaker
+(
+    id                  uuid primary key,
+    arena_id            float NOT NULL,
+    person_id           float NOT NULL,
+    gjennomforing_id    float not null,
+    dato_fra            date,
+    dato_til            date,
+    reg_dato            timestamp with time zone not null,
+    mod_dato            timestamp with time zone not null,
+    status              varchar not null,
+    dato_statusendring  timestamp with time zone not null,
+    ekstern_id          uuid,
+    arena_source_table  varchar not null,
+    created_at          timestamp with time zone default current_timestamp,
+    modified_at         timestamp with time zone default current_timestamp,
+
+    UNIQUE (arena_id, arena_source_table)
+);

--- a/src/main/resources/db/migration/V17__table_deltaker.sql
+++ b/src/main/resources/db/migration/V17__table_deltaker.sql
@@ -8,10 +8,10 @@ CREATE TABLE deltaker
     dato_til            date,
     reg_dato            timestamp with time zone not null,
     mod_dato            timestamp with time zone not null,
-    status              varchar not null,
+    status              varchar(16) not null,
     dato_statusendring  timestamp with time zone not null,
     ekstern_id          uuid,
-    arena_source_table  varchar not null,
+    arena_source_table  varchar(16) not null,
     created_at          timestamp with time zone default current_timestamp,
     modified_at         timestamp with time zone default current_timestamp,
 

--- a/src/main/resources/db/migration/V17__table_deltaker.sql
+++ b/src/main/resources/db/migration/V17__table_deltaker.sql
@@ -8,10 +8,10 @@ CREATE TABLE deltaker
     dato_til            date,
     reg_dato            timestamp with time zone not null,
     mod_dato            timestamp with time zone not null,
-    status              varchar(16) not null,
+    status              varchar not null,
     dato_statusendring  timestamp with time zone not null,
     ekstern_id          uuid,
-    arena_source_table  varchar(16) not null,
+    arena_source_table  varchar not null,
     created_at          timestamp with time zone default current_timestamp,
     modified_at         timestamp with time zone default current_timestamp,
 

--- a/src/test/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepositoryTest.kt
@@ -40,6 +40,30 @@ class DeltakerRepositoryTest : FunSpec({
 		deltaker!!.toInsertDbo() shouldBe dbo
 	}
 
+	test("upsert - skal oppdatere") {
+		val arenaId = 34234L
+		val dbo = DeltakerInsertDbo(
+			arenaId = arenaId,
+			personId = 5543534,
+			gjennomforingId = 32354,
+			datoFra = "2016-03-01 00:00:00".asLocalDate(),
+			datoTil = "2016-03-02 00:00:00".asLocalDate(),
+			regDato = "2016-03-17 14:21:17".asLocalDateTime(),
+			modDato = "2016-03-18 14:21:17".asLocalDateTime(),
+			status = "status",
+			datoStatusEndring = "2018-03-18 14:21:17".asLocalDateTime(),
+			eksternId = UUID.randomUUID(),
+			arenaSourceTable = ARENA_DELTAKER_TABLE_NAME,
+		)
+		val dbo2 = dbo.copy(datoFra = "2016-02-01 00:00:00".asLocalDate())
+		repository.upsert(dbo)
+		repository.upsert(dbo2)
+
+
+		val deltaker = repository.get(arenaId, ARENA_DELTAKER_TABLE_NAME)
+		deltaker!!.toInsertDbo() shouldBe dbo2
+	}
+
 })
 
 fun DeltakerDbo.toInsertDbo(): DeltakerInsertDbo = DeltakerInsertDbo(

--- a/src/test/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/repositories/DeltakerRepositoryTest.kt
@@ -1,0 +1,57 @@
+package no.nav.amt.arena.acl.repositories
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.amt.arena.acl.database.DatabaseTestUtils
+import no.nav.amt.arena.acl.database.SingletonPostgresContainer
+import no.nav.amt.arena.acl.utils.ARENA_DELTAKER_TABLE_NAME
+import no.nav.amt.arena.acl.utils.asLocalDate
+import no.nav.amt.arena.acl.utils.asLocalDateTime
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import java.util.UUID
+
+class DeltakerRepositoryTest : FunSpec({
+	val dataSource = SingletonPostgresContainer.getDataSource()
+	lateinit var repository: DeltakerRepository
+
+	beforeEach {
+		repository = DeltakerRepository(NamedParameterJdbcTemplate(dataSource))
+		DatabaseTestUtils.cleanDatabase(dataSource)
+	}
+
+	test("upsert - skal upserte ny deltaker") {
+		val arenaId = 34234L
+		val dbo = DeltakerInsertDbo(
+			arenaId = arenaId,
+			personId = 5543534,
+			gjennomforingId = 32354,
+			datoFra = "2016-03-01 00:00:00".asLocalDate(),
+			datoTil = "2016-03-02 00:00:00".asLocalDate(),
+			regDato = "2016-03-17 14:21:17".asLocalDateTime(),
+			modDato = "2016-03-18 14:21:17".asLocalDateTime(),
+			status = "status",
+			datoStatusEndring = "2018-03-18 14:21:17".asLocalDateTime(),
+			eksternId = UUID.randomUUID(),
+			arenaSourceTable = ARENA_DELTAKER_TABLE_NAME,
+		)
+		repository.upsert(dbo)
+
+		val deltaker = repository.get(arenaId, ARENA_DELTAKER_TABLE_NAME)
+		deltaker!!.toInsertDbo() shouldBe dbo
+	}
+
+})
+
+fun DeltakerDbo.toInsertDbo(): DeltakerInsertDbo = DeltakerInsertDbo(
+	arenaId = arenaId,
+	personId = personId,
+	gjennomforingId = gjennomforingId,
+	datoFra = datoFra,
+	datoTil = datoTil,
+	regDato = regDato,
+	modDato = modDato,
+	status = status,
+	datoStatusEndring = datoStatusEndring,
+	arenaSourceTable = arenaSourceTable,
+	eksternId = eksternId,
+)


### PR DESCRIPTION
Problemstilling: Vi kobler nå hist deltakere med eksisterende vha fra og tildato på deltakerene. Dette viser seg å ikke fungere optimalt, fordi det er mange deltakere hvor hist deltakeren og den aktive har samme datoer uten å være den samme.

Derfor skal vi nå lagre mer arenaspesifikk data om deltaker, slik at vi skal kunne matche og opprette hist deltakere der det er nødvendig
https://trello.com/c/f1e6xOKO/1839-deltakere-fra-har-blitt-feilaktig-koblet-sammen

**Plan:**
- [x] Begynne å lagre arenaspesifikke strukturerte data om deltakere
- [ ] Rekjøre deltakere i dev og prod slik at vi får lagret dataene vi trenger
- [ ] Utvide matchingen slik at arena mod dato også må være lik på hist deltaker og vår deltaker for at de skal tolkes som samme deltaker, potensielt også flere felter som er arena spesifikke, og deretter publisere de hist deltakerene på amt-tiltak topic 
- [ ] Kontrollmekanismer som sørger for at vi ikke lager aktiv status på hist deltakerene som sendes videre
- [ ] Kontrollmekanismer som sørger for at vi ikke lager aktiv status på hist deltakerene som sendes videre

