### PR TITLE
Bump dependencies - 20250305103148

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <kotest.version>5.9.1</kotest.version>
-        <testcontainers.version>1.20.5</testcontainers.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
         <okhttp.version>4.12.0</okhttp.version>
         <nimbus.version>11.23.1</nimbus.version>
         <token-support.version>5.0.19</token-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <schedlock.version>6.3.0</schedlock.version>
         <logstashencoder.version>8.0</logstashencoder.version>
         <mockk.version>1.13.17</mockk.version>
-        <unleash.version>10.0.2</unleash.version>
+        <unleash.version>10.1.0</unleash.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250305103148 branch:

- [Bump testcontainers.version from 1.20.5 to 1.20.6](https://github.com/navikt/amt-arena-acl/pull/456)
- [Bump io.getunleash:unleash-client-java from 10.0.2 to 10.1.0](https://github.com/navikt/amt-arena-acl/pull/455)
