### PR TITLE
Bump dependencies - 20250613101638

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <schedlock.version>6.9.0</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
         <mockk.version>1.14.2</mockk.version>
-        <unleash.version>10.2.2</unleash.version>
+        <unleash.version>11.0.0</unleash.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <okhttp.version>4.12.0</okhttp.version>
         <nimbus.version>11.25</nimbus.version>
         <token-support.version>5.0.29</token-support.version>
-        <schedlock.version>6.7.0</schedlock.version>
+        <schedlock.version>6.9.0</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
         <mockk.version>1.14.2</mockk.version>
         <unleash.version>10.2.2</unleash.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250613101638 branch:

## Successfully Rebased PRs
- [Bump io.getunleash:unleash-client-java from 10.2.2 to 11.0.0](https://github.com/navikt/amt-arena-acl/pull/497)
- [Bump schedlock.version from 6.7.0 to 6.9.0](https://github.com/navikt/amt-arena-acl/pull/496)


