### PR TITLE
Bump dependencies - 20250623091258

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <kotest.version>5.9.1</kotest.version>
-        <testcontainers.version>1.21.1</testcontainers.version>
+        <testcontainers.version>1.21.2</testcontainers.version>
         <okhttp.version>4.12.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
         <token-support.version>5.0.29</token-support.version>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <testcontainers.version>1.21.2</testcontainers.version>
         <okhttp.version>4.12.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
-        <token-support.version>5.0.29</token-support.version>
+        <token-support.version>5.0.30</token-support.version>
         <schedlock.version>6.9.0</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
         <mockk.version>1.14.2</mockk.version>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>3.5.0</version>
+        <version>3.5.3</version>
     </parent>
 
     <properties>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250623091258 branch:

## Successfully Rebased PRs
- [Bump token-support.version from 5.0.29 to 5.0.30](https://github.com/navikt/amt-arena-acl/pull/503)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.0 to 3.5.3](https://github.com/navikt/amt-arena-acl/pull/502)
- [Bump testcontainers.version from 1.21.1 to 1.21.2](https://github.com/navikt/amt-arena-acl/pull/501)


