### PR TITLE
Bump dependencies - 20250627145342

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.code.style>official</kotlin.code.style>
         <kotlin.compiler.jvmTarget>21</kotlin.compiler.jvmTarget>
-        <kotlin.version>2.1.21</kotlin.version>
+        <kotlin.version>2.2.0</kotlin.version>
         <java.version>21</java.version>
 
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <token-support.version>5.0.30</token-support.version>
         <schedlock.version>6.9.0</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
-        <mockk.version>1.14.2</mockk.version>
+        <mockk.version>1.14.4</mockk.version>
         <unleash.version>11.0.0</unleash.version>
     </properties>
 


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250627145342 branch:

## Successfully Rebased PRs
- [Bump mockk.version from 1.14.2 to 1.14.4](https://github.com/navikt/amt-arena-acl/pull/506)
- [Bump kotlin.version from 2.1.21 to 2.2.0](https://github.com/navikt/amt-arena-acl/pull/505)


