### PR TITLE
Bump dependencies - 20250704094829

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <kotest.version>5.9.1</kotest.version>
         <testcontainers.version>1.21.3</testcontainers.version>
-        <okhttp.version>4.12.0</okhttp.version>
+        <okhttp.version>5.0.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
         <token-support.version>5.0.30</token-support.version>
         <schedlock.version>6.9.0</schedlock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <schedlock.version>6.9.0</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
         <mockk.version>1.14.4</mockk.version>
-        <unleash.version>11.0.0</unleash.version>
+        <unleash.version>11.0.1</unleash.version>
     </properties>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>okhttp</artifactId>
+            <artifactId>okhttp-jvm</artifactId>
             <version>${okhttp.version}</version>
         </dependency>
         <dependency>
@@ -182,6 +182,12 @@
             <groupId>no.nav.common</groupId>
             <artifactId>job</artifactId>
             <version>${common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>no.nav.common</groupId>
@@ -192,6 +198,12 @@
             <groupId>no.nav.common</groupId>
             <artifactId>token-client</artifactId>
             <version>${common.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.getunleash</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <kotest.version>5.9.1</kotest.version>
-        <testcontainers.version>1.21.2</testcontainers.version>
+        <testcontainers.version>1.21.3</testcontainers.version>
         <okhttp.version>4.12.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
         <token-support.version>5.0.30</token-support.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250704094829 branch:

## Successfully Rebased PRs
- [Bump okhttp.version from 4.12.0 to 5.0.0](https://github.com/navikt/amt-arena-acl/pull/511)
- [Bump io.getunleash:unleash-client-java from 11.0.0 to 11.0.1](https://github.com/navikt/amt-arena-acl/pull/509)
- [Bump testcontainers.version from 1.21.2 to 1.21.3](https://github.com/navikt/amt-arena-acl/pull/508)


