### PR TITLE
Bump dependencies - 20250708105727

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <okhttp.version>5.1.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
         <token-support.version>5.0.30</token-support.version>
-        <schedlock.version>6.9.0</schedlock.version>
+        <schedlock.version>6.9.2</schedlock.version>
         <logstashencoder.version>8.1</logstashencoder.version>
         <mockk.version>1.14.4</mockk.version>
         <unleash.version>11.0.2</unleash.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <common.version>3.2024.10.25_13.44-9db48a0dbe67</common.version>
         <kotest.version>5.9.1</kotest.version>
         <testcontainers.version>1.21.3</testcontainers.version>
-        <okhttp.version>5.0.0</okhttp.version>
+        <okhttp.version>5.1.0</okhttp.version>
         <nimbus.version>11.26</nimbus.version>
         <token-support.version>5.0.30</token-support.version>
         <schedlock.version>6.9.0</schedlock.version>


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250708105727 branch:

## Successfully Rebased PRs
- [Bump schedlock.version from 6.9.0 to 6.9.2](https://github.com/navikt/amt-arena-acl/pull/515)
- [Bump okhttp.version from 5.0.0 to 5.1.0](https://github.com/navikt/amt-arena-acl/pull/514)


