### PR TITLE
Bruker nå bellsoft/liberica-openjdk-alpine-musl:21 som base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM gcr.io/distroless/java21-debian12:nonroot
+FROM bellsoft/liberica-openjdk-alpine-musl:21
 WORKDIR /app
 ARG JAR_FILE=build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 ENV TZ="Europe/Oslo"
 EXPOSE 8080
-CMD ["app.jar"]
+ENTRYPOINT ["java","-jar","app.jar"]


### PR DESCRIPTION
- Med opprinnelig Docker base image `gcr.io/distroless/java21-debian12:nonroot`: 259MB
- Med `bellsoft/liberica-openjdk-alpine-musl:21`:  179MB (30% mindre Docker image)
- Med `bellsoft/liberica-openjdk-alpine:21`: 205MB (21% mindre Docker image)

Jeg har tidligere benyttet `bellsoft/liberica-openjdk-alpine-musl:21` hos SSB med NAIS, så det bør fungere også her, men må selvfølgelig verifiseres. 

[Eksempel på public SSB-repo hvor dette er benyttet](https://github.com/statisticsnorway/kostra-kontrollprogram/blob/master/web/Dockerfile)

Benytter `bellsoft/liberica-openjdk-alpine-musl:21` for både Spring Boot og Ktor i dette repoet: https://github.com/roar-skinderviken/vicx-applications, men her kjører appene i et Microk8s-cluster som kjører på Raspberry PIs med Ubuntu Server 24.04.