### PR TITLE
Byttet ut 'management.endpoint.prometheus.enabled' som er deprikert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,10 @@ dependencies {
 kotlin {
     jvmToolchain(21)
     compilerOptions {
-        freeCompilerArgs.add("-Xjsr305=strict")
+        freeCompilerArgs.addAll(
+            "-Xjsr305=strict",
+            "-Xannotation-default-target=param-property",
+        )
     }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,13 +5,12 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.hikari.maximum-pool-size=4
 
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
+management.endpoint.prometheus.access=read_only
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoints.web.base-path=/internal
 management.endpoints.web.exposure.include=prometheus,health
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
 
 nais.env.azureAppClientId=${AZURE_APP_CLIENT_ID:#{null}}
 nais.env.azureAppJWK=${AZURE_APP_JWK:#{null}}

--- a/src/test/kotlin/no/nav/amt/arena/acl/ActuatorTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/ActuatorTest.kt
@@ -1,0 +1,61 @@
+package no.nav.amt.arena.acl
+
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.shouldBe
+import no.nav.amt.arena.acl.integration.IntegrationTestBase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.boot.test.web.server.LocalManagementPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.util.UriComponentsBuilder
+import kotlin.jvm.java
+
+class ActuatorTest(
+	@LocalManagementPort private val managementPort: Int,
+	private val restTemplate: TestRestTemplate,
+) : IntegrationTestBase() {
+	@ParameterizedTest(name = "{0} probe skal returnere OK og status = UP")
+	@ValueSource(strings = ["liveness", "readiness"])
+	fun probe_skal_returnere_OK_og_status_UP(probeName: String) {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/health/{probeName}")
+				.buildAndExpand(managementPort, probeName)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		assertSoftly(response) {
+			statusCode shouldBe HttpStatus.OK
+			body shouldBe "{\"status\":\"UP\"}"
+		}
+	}
+
+	@Test
+	fun `Prometheus-endepunktet skal returnere OK`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/prometheus")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.OK
+	}
+
+	@Test
+	fun `Metrics-endepunktet skal returnere NOT_FOUND`() {
+		val uri =
+			UriComponentsBuilder
+				.fromUriString("http://localhost:{port}/internal/metrics")
+				.buildAndExpand(managementPort)
+				.toUri()
+
+		val response = restTemplate.getForEntity(uri, String::class.java)
+
+		response.statusCode shouldBe HttpStatus.NOT_FOUND
+	}
+}

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,5 +1,3 @@
-spring.main.banner-mode=off
-
 # Enables colors for log output
 spring.output.ansi.enabled=always
 
@@ -9,14 +7,6 @@ app.env.arenaTiltakGjennomforingTopic=gjennomforing
 app.env.arenaTiltakDeltakerTopic=deltaker
 app.env.arenaHistTiltakDeltakerTopic=histdeltaker
 app.env.amtTopic=amt_topic
-
-management.endpoint.metrics.enabled=true
-management.endpoint.prometheus.enabled=true
-management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState
-management.endpoints.web.base-path=/internal
-management.endpoints.web.exposure.include=prometheus,health
-management.metrics.export.prometheus.enabled=true
 
 no.nav.security.jwt.issuer.tokenx.discovery-url=http://localhost:8082/local-tokenx/.well-known/openid-configuration
 no.nav.security.jwt.issuer.tokenx.accepted-audience=somescope


### PR DESCRIPTION
- Byttet ut deprikert `management.metrics.export.prometheus.enabled`  med `management.prometheus.metrics.export.enabled`
- Byttet ut deprikert  `management.endpoint.prometheus.enabled` med management.endpoint.prometheus.access. [Spring-Boot-3.4-Configuration-Changelog](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.4-Configuration-Changelog)
- Fjernet deprikert `management.endpoint.metrics.enabled=true` fordi denne ikke er med i management.endpoints.web.exposure.include og er dermed overflødig.
- Fjernet entries fra application-local.properties hvor nøkkel/verdi var lik som i application.properties.
- Lagt til tester for actuator-endepunktene

@tofoss : Dette repoet skiller seg ut ved at testen `Prometheus-endepunktet skal returnere OK` ikke passerte med opprinnelig kode. 