### PR TITLE
Bump dependencies - 20250728094834

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
     maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
 }
 
-val nimbusVersion = "11.26"
+val nimbusVersion = "11.26.1"
 val okhttpVersion = "5.1.0"
 val shedlockVersion = "6.9.2"
 val unleashVersion = "11.0.2"


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250728094834 branch:

## Successfully Rebased PRs
- [Bump com.nimbusds:oauth2-oidc-sdk from 11.26 to 11.26.1](https://github.com/navikt/amt-arena-acl/pull/526)
- [Bump org.springframework.boot from 3.5.3 to 3.5.4](https://github.com/navikt/amt-arena-acl/pull/525)
- [Bump navTokenSupportVersion from 5.0.30 to 5.0.33](https://github.com/navikt/amt-arena-acl/pull/524)


