### PR TITLE
Bump dependencies - 20250909094341

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,7 +32,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 21

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: 21

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val okhttpVersion = "5.1.0"
 val shedlockVersion = "6.10.0"
 val unleashVersion = "11.1.0"
 val navCommonVersion = "3.2025.08.19_06.12-48301d0f4239"
-val navTokenSupportVersion = "5.0.34"
+val navTokenSupportVersion = "5.0.36"
 val logstashEncoderVersion = "8.1"
 
 val kotestVersion = "5.9.1"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -81,8 +81,8 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus")
 
     testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion")
-    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:${kotestExtensionsTestcontainersVersion}")
-    testImplementation("io.kotest.extensions:kotest-extensions-spring:$kotestExtensionsSpringVersion")
+    testImplementation("io.kotest:kotest-extensions-spring:${kotestVersion}")
+    testImplementation("io.kotest:kotest-extensions-testcontainers:${kotestVersion}")
     testImplementation("io.mockk:mockk-jvm:$mockkVersion")
     testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
     testImplementation("no.nav.security:token-validation-spring-test:$navTokenSupportVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ val nimbusVersion = "11.28"
 val okhttpVersion = "5.1.0"
 val shedlockVersion = "6.10.0"
 val unleashVersion = "11.1.0"
-val navCommonVersion = "3.2025.08.19_06.12-48301d0f4239"
+val navCommonVersion = "3.2025.09.03_08.33-728ff4acbfdb"
 val navTokenSupportVersion = "5.0.36"
 val logstashEncoderVersion = "8.1"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
     maven("https://github-package-registry-mirror.gc.nav.no/cached/maven-release")
 }
 
-val nimbusVersion = "11.27.1"
+val nimbusVersion = "11.28"
 val okhttpVersion = "5.1.0"
 val shedlockVersion = "6.10.0"
 val unleashVersion = "11.1.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ val navCommonVersion = "3.2025.09.03_08.33-728ff4acbfdb"
 val navTokenSupportVersion = "5.0.36"
 val logstashEncoderVersion = "8.1"
 
-val kotestVersion = "5.9.1"
+val kotestVersion = "6.0.3"
 val mockkVersion = "1.14.5"
 val springmockkVersion = "4.0.2"
 val testcontainersVersion = "1.21.3"

--- a/src/test/kotlin/no/nav/amt/arena/acl/KotestConfig.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/KotestConfig.kt
@@ -1,7 +1,6 @@
 package no.nav.amt.arena.acl
 
 import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.extensions.spring.SpringAutowireConstructorExtension
 import io.kotest.extensions.spring.SpringExtension
 import org.springframework.core.env.AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME
 
@@ -10,9 +9,7 @@ object KotestConfig : AbstractProjectConfig() {
 		System.setProperty(ACTIVE_PROFILES_PROPERTY_NAME, "test")
 	}
 
-	override fun extensions() =
-        listOf(
-            SpringExtension,
-            SpringAutowireConstructorExtension,
+	override val extensions = listOf(
+            SpringExtension(),
         )
 }

--- a/src/test/kotlin/no/nav/amt/arena/acl/repositories/KotestRepositoryTestBase.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/repositories/KotestRepositoryTestBase.kt
@@ -17,7 +17,7 @@ abstract class KotestRepositoryTestBase(
 	private lateinit var dataSource: DataSource
 
 	init {
-		listener(container.perSpec())
+		extensions(container.perSpec())
 
 		afterTest {
 			cleanDatabase(dataSource)


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250909094341 branch:

## Successfully Rebased PRs
- [Bump io.kotest:kotest-runner-junit5-jvm from 5.9.1 to 6.0.3](https://github.com/navikt/amt-arena-acl/pull/559)
- [Bump no.nav.common:kafka from 3.2025.08.19_06.12-48301d0f4239 to 3.2025.09.03_08.33-728ff4acbfdb](https://github.com/navikt/amt-arena-acl/pull/552)
- [Bump navTokenSupportVersion from 5.0.34 to 5.0.36](https://github.com/navikt/amt-arena-acl/pull/550)
- [Bump com.nimbusds:oauth2-oidc-sdk from 11.27.1 to 11.28](https://github.com/navikt/amt-arena-acl/pull/549)
- [Bump actions/setup-java from 4 to 5](https://github.com/navikt/amt-arena-acl/pull/541)


