### PR TITLE
Bump dependencies - 20250919083439

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ val okhttpVersion = "5.1.0"
 val shedlockVersion = "6.10.0"
 val unleashVersion = "11.1.0"
 val navCommonVersion = "3.2025.09.03_08.33-728ff4acbfdb"
-val navTokenSupportVersion = "5.0.36"
+val navTokenSupportVersion = "5.0.37"
 val logstashEncoderVersion = "8.1"
 
 val kotestVersion = "6.0.3"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     val kotlinVersion = "2.2.20"
-    val springBootVersion = "3.5.5"
+    val springBootVersion = "3.5.6"
     val springDependencyManagementVersion = "1.1.7"
 
     kotlin("jvm") version kotlinVersion


### PR DESCRIPTION
This PR includes the following Dependabot updates rebased into the bump-deps-20250919083439 branch:

## Successfully Rebased PRs
- [Bump org.springframework.boot from 3.5.5 to 3.5.6](https://github.com/navikt/amt-arena-acl/pull/564)
- [Bump navTokenSupportVersion from 5.0.36 to 5.0.37](https://github.com/navikt/amt-arena-acl/pull/563)


