### PR TITLE
Mapper enkeltplass deltakere til aktiv status selv om gjennomføringen

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/consumer/converters/ArenaDeltakerStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/consumer/converters/ArenaDeltakerStatusConverter.kt
@@ -36,6 +36,15 @@ class ArenaDeltakerStatusConverter(
 				throw UnknownFormatConversionException("Kan ikke konvertere deltakerstatuskode: $arenaStatus")
 			}
 
+		/* Enkeltplasser kan få gjennomføringen automatisk avsluttet mens personen fortsatt deltar(som en schedulert batch kjøring i arena).
+				Deltakelsen blir da automatisk avsluttet. Deretter gjenåper de deltakelsen men gjennomføringen forblir avsluttet.
+				Derfor skal vi ikke avslutte deltakelsen selv om gjennomføringen er avsluttet.
+			 */
+		if(erEnkeltplass && erGjennomforingAvsluttet && !status.navn.erAvsluttende()) {
+			if(arenaStatus.erSoktInn()) { // Har ikke egentlig deltatt selv om gjennomføring er avsluttet
+				return DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, datoStatusEndring)
+			}
+		}
 		if (!erEnkeltplass && (erGjennomforingAvsluttet && !status.navn.erAvsluttende())) {
 			return DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, datoStatusEndring)
 		}
@@ -50,6 +59,7 @@ class ArenaDeltakerStatusConverter(
 		} else if (arenaStatus.erGjennomforende()) {
 			status =
 				if (startDatoHarPassert() && sluttDatoHarPassert() && sluttetForTidlig()) {
+					//Kurs skal ha avbrutt status hvis man slutter for tidlig(i motsetning til andre tiltakstyper)
 					DeltakerStatus(AmtDeltaker.Status.AVBRUTT, deltakerSluttdato?.atStartOfDay())
 				} else {
 					utledGjennomforendeStatus()

--- a/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
@@ -889,7 +889,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 
 	"erEnkeltplass=true og gjennomforing avsluttet - GJENN - returnerer Deltar" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.VENTELISTE,
+			TiltakDeltaker.Status.GJENN,
 			now,
 			LocalDate.now().minusDays(2),
 			LocalDate.now().plusDays(2),

--- a/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
@@ -859,7 +859,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 
-	"erEnkeltplass=true og gjennomforing avsluttet - AKTUELL - returnerer SOKT_INN" {
+	"erEnkeltplass=true og gjennomforing avsluttet - AKTUELL - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.AKTUELL,
 			now,
@@ -869,11 +869,11 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
-			false
-		).convert().navn shouldBe SOKT_INN
+			true
+		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
-	"erEnkeltplass=true og gjennomforing avsluttet - INFOMOETE - returnerer VURDERES" {
+	"erEnkeltplass=true og gjennomforing avsluttet - INFOMOETE - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.INFOMOETE,
 			now,
@@ -884,10 +884,24 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
 			false
-		).convert().navn shouldBe VURDERES
+		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
-	"erEnkeltplass=true og gjennomforing avsluttet - VENTELISTE - returnerer VENTELISTE" {
+	"erEnkeltplass=true og gjennomforing avsluttet - GJENN - returnerer Deltar" {
+		ArenaDeltakerStatusConverter(
+			TiltakDeltaker.Status.VENTELISTE,
+			now,
+			LocalDate.now().minusDays(2),
+			LocalDate.now().plusDays(2),
+			true,
+			null,
+			erGjennomforingAvsluttet,
+			LocalDate.now(),
+			false
+		).convert().navn shouldBe DELTAR
+	}
+
+	"erEnkeltplass=true og gjennomforing avsluttet - VENTELISTE - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
 			TiltakDeltaker.Status.VENTELISTE,
 			now,
@@ -898,7 +912,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
 			false
-		).convert().navn shouldBe VENTELISTE
+		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
 	// Avsluttende statuser skal passere gjennom uavhengig av erEnkeltplass


### PR DESCRIPTION
Mapper enkeltplass deltakere til aktiv status selv om gjennomføringen er avsluttet fordi gjennomføringer blir avsluttet automatisk i arena i en batch kjøring som ikke skal føre til avsluttende deltaker status

(vi må undersøke litt før merging)