### PR TITLE
Det er kun AVSLUTT gjennomføringer i kombinasjon med GJENN deltaker som skal gi aktiv status

### DIFF
--- a/src/main/kotlin/no/nav/amt/arena/acl/consumer/ArenaDeltakerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/consumer/ArenaDeltakerConsumer.kt
@@ -208,10 +208,8 @@ class ArenaDeltakerConsumer(
 
 		return arenaDeltaker.constructDeltaker(
 			amtDeltakerId = deltakerId,
-			gjennomforingId = gjennomforing.id,
-			gjennomforingSluttDato = gjennomforing.sluttDato,
+			gjennomforing = gjennomforing,
 			erEnkeltplass = gjennomforing.erEnkelplass(),
-			erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
 			deltakelseKreverGodkjenningLoep = gjennomforing.erKurs() || gjennomforing.erEnkelplass(),
 			personIdent = personIdent,
 		)

--- a/src/main/kotlin/no/nav/amt/arena/acl/consumer/ArenaDeltakerConsumerTemp.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/consumer/ArenaDeltakerConsumerTemp.kt
@@ -122,10 +122,8 @@ class ArenaDeltakerConsumerTemp(
 
 		return arenaDeltaker.constructDeltaker(
 			amtDeltakerId = deltakerId,
-			gjennomforingId = gjennomforing.id,
-			gjennomforingSluttDato = gjennomforing.sluttDato,
+			gjennomforing = gjennomforing,
 			erEnkeltplass = gjennomforing.erEnkelplass(),
-			erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
 			deltakelseKreverGodkjenningLoep = gjennomforing.erKurs() || gjennomforing.erEnkelplass(),
 			personIdent = personIdent,
 		)

--- a/src/main/kotlin/no/nav/amt/arena/acl/consumer/HistDeltakerConsumer.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/consumer/HistDeltakerConsumer.kt
@@ -156,10 +156,8 @@ class HistDeltakerConsumer(
 		val deltaker =
 			arenaDeltaker.constructDeltaker(
 				amtDeltakerId = amtDeltakerId,
-				gjennomforingId = gjennomforing.id,
-				gjennomforingSluttDato = gjennomforing.sluttDato,
+				gjennomforing = gjennomforing,
 				erEnkeltplass = gjennomforing.erEnkelplass(),
-				erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
 				deltakelseKreverGodkjenningLoep = gjennomforing.erKurs() || gjennomforing.erEnkelplass(),
 				personIdent = personIdent,
 			)

--- a/src/main/kotlin/no/nav/amt/arena/acl/consumer/converters/ArenaDeltakerStatusConverter.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/consumer/converters/ArenaDeltakerStatusConverter.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.arena.acl.consumer.converters
 
+import no.nav.amt.arena.acl.clients.mulighetsrommet.Gjennomforing
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker
 import no.nav.amt.arena.acl.domain.kafka.amt.erAvsluttende
 import no.nav.amt.arena.acl.domain.kafka.arena.TiltakDeltaker
@@ -16,6 +17,7 @@ class ArenaDeltakerStatusConverter(
 	val datoStatusEndring: LocalDateTime?,
 	val erGjennomforingAvsluttet: Boolean,
 	val gjennomforingSluttdato: LocalDate?,
+	val gjennomforingStatus: Gjennomforing.Status?,
 	val deltakelseKreverGodkjenningLoep: Boolean,
 ) {
 	fun convert(): DeltakerStatus {
@@ -35,17 +37,17 @@ class ArenaDeltakerStatusConverter(
 			} else {
 				throw UnknownFormatConversionException("Kan ikke konvertere deltakerstatuskode: $arenaStatus")
 			}
-
 		/* Enkeltplasser kan få gjennomføringen automatisk avsluttet mens personen fortsatt deltar(som en schedulert batch kjøring i arena).
-				Deltakelsen blir da automatisk avsluttet. Deretter gjenåper de deltakelsen men gjennomføringen forblir avsluttet.
-				Derfor skal vi ikke avslutte deltakelsen selv om gjennomføringen er avsluttet.
-			 */
-		if(erEnkeltplass && erGjennomforingAvsluttet && !status.navn.erAvsluttende()) {
-			if(arenaStatus.erSoktInn()) { // Har ikke egentlig deltatt selv om gjennomføring er avsluttet
-				return DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, datoStatusEndring)
-			}
+		Deltakelsen blir da automatisk avsluttet. Deretter gjenåper de deltakelsen men gjennomføringen forblir avsluttet.
+		Derfor skal vi ikke avslutte deltakelsen selv om gjennomføringen er avsluttet.
+		Disse tilfellene har Gjennomføringen status AVSLUTT og deltakerstatus er GJENN
+		https://trello.com/c/WYQa8pU8/257-endre-mappinglogikk-p%C3%A5-enkeltplass-oppl%C3%A6ringstiltakene
+	 */
+		if(erEnkeltplass && gjennomforingStatus == Gjennomforing.Status.AVSLUTTET && arenaStatus == TiltakDeltaker.Status.GJENN) {
+			return status
 		}
-		if (!erEnkeltplass && (erGjennomforingAvsluttet && !status.navn.erAvsluttende())) {
+
+		else if (erGjennomforingAvsluttet && !status.navn.erAvsluttende()) {
 			return DeltakerStatus(AmtDeltaker.Status.IKKE_AKTUELL, datoStatusEndring)
 		}
 		return status

--- a/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
+++ b/src/main/kotlin/no/nav/amt/arena/acl/domain/kafka/arena/TiltakDeltaker.kt
@@ -1,5 +1,6 @@
 package no.nav.amt.arena.acl.domain.kafka.arena
 
+import no.nav.amt.arena.acl.clients.mulighetsrommet.Gjennomforing
 import no.nav.amt.arena.acl.consumer.converters.ArenaDeltakerAarsakConverter
 import no.nav.amt.arena.acl.consumer.converters.ArenaDeltakerStatusConverter
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker
@@ -51,10 +52,8 @@ data class TiltakDeltaker(
 
 	fun constructDeltaker(
 		amtDeltakerId: UUID,
-		gjennomforingId: UUID,
-		gjennomforingSluttDato: LocalDate?,
 		erEnkeltplass: Boolean,
-		erGjennomforingAvsluttet: Boolean,
+		gjennomforing: Gjennomforing,
 		personIdent: String,
 		deltakelseKreverGodkjenningLoep: Boolean,
 	): AmtDeltaker {
@@ -65,9 +64,10 @@ data class TiltakDeltaker(
 				deltakerSluttdato = datoTil,
 				arenaStatus = deltakerStatusKode,
 				datoStatusEndring = datoStatusendring,
-				gjennomforingSluttdato = gjennomforingSluttDato,
+				gjennomforingSluttdato = gjennomforing.sluttDato,
 				erEnkeltplass = erEnkeltplass,
-				erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+				erGjennomforingAvsluttet = gjennomforing.erAvsluttet(),
+				gjennomforingStatus = gjennomforing.status,
 				deltakelseKreverGodkjenningLoep = deltakelseKreverGodkjenningLoep,
 			).convert()
 		val statusAarsak =
@@ -75,12 +75,12 @@ data class TiltakDeltaker(
 				deltakerStatusKode,
 				deltakerStatus.navn,
 				statusAarsakKode,
-				erGjennomforingAvsluttet,
+				gjennomforing.erAvsluttet(),
 			)
 
 		return AmtDeltaker(
 			id = amtDeltakerId,
-			gjennomforingId = gjennomforingId,
+			gjennomforingId = gjennomforing.id,
 			personIdent = personIdent,
 			startDato = datoFra,
 			sluttDato = datoTil,

--- a/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
+++ b/src/test/kotlin/no/nav/amt/arena/acl/consumer/DeltakerStatusConverterTest.kt
@@ -2,6 +2,7 @@ package no.nav.amt.arena.acl.consumer
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import no.nav.amt.arena.acl.clients.mulighetsrommet.Gjennomforing
 import no.nav.amt.arena.acl.consumer.converters.ArenaDeltakerStatusConverter
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.AVBRUTT
 import no.nav.amt.arena.acl.domain.kafka.amt.AmtDeltaker.Status.DELTAR
@@ -22,15 +23,16 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 
 	"status - AKTUELL - returnerer SOKT_INN" {
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.AKTUELL,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.AKTUELL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 
 		status.navn shouldBe SOKT_INN
@@ -38,15 +40,16 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 
 	"status - FEILREG - returnerer FEILREGISTRERT" {
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FEILREG,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.FEILREG,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 
 		status.navn shouldBe FEILREGISTRERT
@@ -54,13 +57,15 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 
 	"status - AVSLAG og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.AVSLAG,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.AVSLAG,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
@@ -72,88 +77,101 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			false,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			erGjennomforingAvsluttet, LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			false,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - DELAVB og har startdato før endretdato - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.DELAVB,
-			now,
-			yesterday.minusDays(1),
-			null,
-			false,
-			yesterday.atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.DELAVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.DELAVB,
-			now,
-			yesterday.minusDays(1),
-			null,
-			false,
-			yesterday.atStartOfDay(),
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			arenaStatus = TiltakDeltaker.Status.DELAVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false,
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - DELAVB og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.DELAVB,
-			now,
-			yesterday,
-			null,
-			false,
-			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.DELAVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.minusDays(1).atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.DELAVB,
-			now,
-			yesterday,
-			null,
-			false,
-			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.DELAVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.minusDays(1).atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - DELAVB og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.DELAVB,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			arenaStatus = TiltakDeltaker.Status.DELAVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - FULLF og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FULLF,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false,
+			arenaStatus = TiltakDeltaker.Status.FULLF,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false,
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - FULLF og har startdato før endretdato - returnerer HAR_SLUTTET" {
 		val endretDato = yesterday.atTime(13, 30)
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FULLF,
-			now,
-			endretDato.minusDays(1).toLocalDate(),
-			null,
-			false,
-			endretDato,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.FULLF,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = endretDato.minusDays(1).toLocalDate(),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = endretDato,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe HAR_SLUTTET
 		status.endretDato shouldBe endretDato
@@ -162,15 +180,16 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 		val endretDato = yesterday.minusDays(1).atTime(13, 30)
 
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FULLF,
-			now,
-			yesterday,
-			null,
-			false,
-			endretDato,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.FULLF,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = endretDato,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 
 		status.navn shouldBe IKKE_AKTUELL
@@ -178,55 +197,61 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	}
 	"status - FULLF og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FULLF,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.FULLF,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - FULLF og har endretdato etter sluttdato - returnerer HAR_SLUTTET" {
 		val sluttDato = now.toLocalDate().atTime(12, 30)
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.FULLF,
-			now,
+			arenaStatus = TiltakDeltaker.Status.FULLF,
+			deltakerRegistrertDato = now,
 			deltakerStartdato = sluttDato.minusDays(1).toLocalDate(),
 			deltakerSluttdato = sluttDato.toLocalDate(),
-			false,
+			erEnkeltplass = false,
 			datoStatusEndring = sluttDato,
-			erGjennomforingAvsluttet,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now(),
-			false
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe HAR_SLUTTET
 	}
 
 	"status - GJENN - returnerer VENTER_PÅ_OPPSTART" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - GJENN og har startdato i fortid - returnerer GJENNOMFORES" {
 		val startDato = yesterday.minusDays(1)
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			startDato,
-			null,
-			false,
-			startDato.plusDays(1).atTime(12, 30),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = startDato,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = startDato.plusDays(1).atTime(12, 30),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe DELTAR
 		status.endretDato shouldBe startDato.atStartOfDay()
@@ -234,42 +259,46 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	"status - GJENN og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
 		val datoEndret = tomorrow.atTime(10, 30)
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			datoEndret.plusDays(2).toLocalDate(),
-			null,
-			false,
-			datoEndret,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = datoEndret.plusDays(2).toLocalDate(),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = datoEndret,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe VENTER_PA_OPPSTART
 		status.endretDato shouldBe datoEndret
 	}
 	"status - GJENN og har sluttdato i fortid - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			yesterday.minusDays(1),
-			yesterday,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = yesterday,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN og har sluttdato i fremtid - returnerer GJENNOMFORES" {
 		val startDato = yesterday
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			startDato,
-			tomorrow.plusDays(1),
-			false,
-			tomorrow.atTime(10, 20),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = startDato,
+			deltakerSluttdato = tomorrow.plusDays(1),
+			erEnkeltplass = false,
+			datoStatusEndring = tomorrow.atTime(10, 20),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe DELTAR
 		status.endretDato shouldBe startDato.atStartOfDay()
@@ -277,13 +306,15 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 	"status - GJENN og har sluttdato har passert - returnerer HAR_SLUTTET" {
 		val sluttDato = yesterday
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN,
-			now,
-			sluttDato.minusDays(1),
-			sluttDato,
-			false,
-			sluttDato.plusDays(1).atTime(10, 20),
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = sluttDato.minusDays(1),
+			deltakerSluttdato = sluttDato,
+			erEnkeltplass = false,
+			datoStatusEndring = sluttDato.plusDays(1).atTime(10, 20),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe HAR_SLUTTET
 		status.endretDato shouldBe sluttDato.atStartOfDay()
@@ -292,61 +323,69 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 
 	"status - GJENN_AVB og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVB,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVB og har startdato før endretdato - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVB,
-			now,
-			yesterday.minusDays(1),
-			null,
-			false,
-			yesterday.atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN_AVB og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVB,
-			now,
-			yesterday,
-			null,
-			false,
-			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.minusDays(1).atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVB og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVB,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVB,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVL,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og har startdato før endretdato - returnerer HAR_SLUTTET" {
@@ -359,46 +398,51 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			yesterday.atStartOfDay(),
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
 			false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - GJENN_AVL og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVL,
-			now,
-			yesterday,
-			null,
-			false,
-			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.minusDays(1).atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - GJENN_AVL og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.GJENN_AVL,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.GJENN_AVL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 
 	"status - IKKAKTUELL - returnerer IKKE_AKTUELL" {
 		val statusEndret = yesterday.minusDays(5)
 		val status = ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKAKTUELL,
-			now,
-			statusEndret.plusDays(2),
-			statusEndret.plusDays(4),
-			false,
-			statusEndret.atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.IKKAKTUELL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = statusEndret.plusDays(2),
+			deltakerSluttdato = statusEndret.plusDays(4),
+			erEnkeltplass = false,
+			datoStatusEndring = statusEndret.atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert()
 		status.navn shouldBe IKKE_AKTUELL
 		status.endretDato shouldBe statusEndret.atStartOfDay()
@@ -406,141 +450,165 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 
 	"status - IKKAKTUELL - returnerer FEILREGISTRERT hvis registrert dato er samme dag som status endring" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKAKTUELL,
-			now,
-			null,
-			null,
-			false,
-			now,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.IKKAKTUELL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = now,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe FEILREGISTRERT
 	}
 
 	"status - IKKEM og mangler startdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKEM,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.IKKEM,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - IKKEM og har startdato før endretdato - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKEM,
-			now,
-			yesterday.minusDays(1),
-			null,
-			false,
-			yesterday.atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.IKKEM,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - IKKEM og har startdato etter endretdato - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKEM,
-			now,
-			yesterday,
-			null,
-			false,
-			yesterday.minusDays(1).atStartOfDay(),
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
+			arenaStatus = TiltakDeltaker.Status.IKKEM,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = yesterday.minusDays(1).atStartOfDay(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - IKKEM og har startdato i fremtid - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.IKKEM,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.IKKEM,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - INFOMOETE - returnerer VURDERES" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.INFOMOETE,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.INFOMOETE,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe VURDERES
 	}
 	"status - JATAKK - returnerer VENTER_PÅ_OPPSTART" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES, deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - JATAKK og har startdato i fortid - returnerer GJENNOMFORES" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			yesterday,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe DELTAR
 	}
 	"status - JATAKK og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
-		).convert().navn shouldBe VENTER_PA_OPPSTART
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false,
+
+			).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - JATAKK og har sluttdato i fortid - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			yesterday.minusDays(1),
-			yesterday,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = yesterday,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - JATAKK og har sluttdato i fremtid - returnerer GJENNOMFORES" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			yesterday,
-			tomorrow,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = tomorrow,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe DELTAR
 	}
 	"status - NEITAKK - returnerer IKKE_AKTUELL" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.NEITAKK,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.NEITAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
 	"status - TILBUD - returnerer VENTER_PÅ_OPPSTART" {
@@ -551,7 +619,9 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			false,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			false
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - TILBUD og har startdato i fortid - returnerer GJENNOMFORES" {
@@ -562,75 +632,90 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			null,
 			false,
 			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			erGjennomforingAvsluttet, LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			false
 		).convert().navn shouldBe DELTAR
 	}
 	"status - TILBUD og har startdato i fremtid - returnerer VENTER_PÅ_OPPSTART" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.TILBUD,
-			now,
-			tomorrow,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.TILBUD,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = tomorrow,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 	"status - TILBUD og har sluttdato i fortid - returnerer HAR_SLUTTET" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.TILBUD,
-			now,
-			yesterday.minusDays(1),
-			yesterday,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.TILBUD,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday.minusDays(1),
+			deltakerSluttdato = yesterday,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
 	"status - TILBUD og har sluttdato i fremtid - returnerer GJENNOMFORES" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.TILBUD,
-			now,
-			yesterday,
-			tomorrow,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.TILBUD,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = tomorrow,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe DELTAR
 	}
 	"status - VENTELISTE - returnerer VENTELISTE" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.VENTELISTE,
-			now,
-			null,
-			null,
-			false,
-			null,
-			erGjennomforingAvsluttet, LocalDate.now(), false
+			arenaStatus = TiltakDeltaker.Status.VENTELISTE,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = null,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = false
 		).convert().navn shouldBe VENTELISTE
 	}
 
 	"convert - VENTELISTE på kurstiltak - returnerer VENTELISTE" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.VENTELISTE,
-			now,
-			LocalDate.now(),
-			null,
-			false,
-			LocalDateTime.now(),
-			erGjennomforingAvsluttet, LocalDate.now(), true
+			arenaStatus = TiltakDeltaker.Status.VENTELISTE,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = LocalDate.now(),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = LocalDateTime.now(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
+			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe VENTELISTE
 	}
 
 	"convert - AKTUELL på kurstiltak - returnerer SOKT_INN" {
 		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.AKTUELL,
-			now,
-			LocalDate.now(),
-			null,
-			false,
-			LocalDateTime.now(),
-			erGjennomforingAvsluttet, LocalDate.now(), true
+			arenaStatus = TiltakDeltaker.Status.AKTUELL,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = LocalDate.now(),
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = LocalDateTime.now(),
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet, gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
+			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe SOKT_INN
 	}
 
@@ -645,6 +730,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().minusDays(5),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe AVBRUTT
 	}
@@ -660,6 +746,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().minusDays(5),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().minusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe FULLFORT
 	}
@@ -674,6 +761,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now(),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
@@ -688,6 +776,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(3),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe FULLFORT
 	}
@@ -702,6 +791,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.GJENNOMFORES,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe FULLFORT
 	}
@@ -716,6 +806,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe AVBRUTT
 	}
@@ -730,6 +821,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(2),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(3),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe AVBRUTT
 	}
@@ -744,6 +836,7 @@ class DeltakerStatusArenaDeltakerStatusConvertererTest : StringSpec({
 			datoStatusEndring = LocalDateTime.now().plusDays(1),
 			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
 			gjennomforingSluttdato = LocalDate.now().plusDays(1),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			deltakelseKreverGodkjenningLoep = true
 		).convert().navn shouldBe FULLFORT
 	}
@@ -770,6 +863,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -784,6 +878,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -798,6 +893,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -813,6 +909,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
@@ -827,36 +924,9 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe DELTAR
-	}
-
-	"erEnkeltplass=true og gjennomforing avsluttet - JATAKK uten startdato - returnerer VENTER_PA_OPPSTART" {
-		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.JATAKK,
-			now,
-			null,
-			null,
-			true,
-			null,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
-		).convert().navn shouldBe VENTER_PA_OPPSTART
-	}
-
-	"erEnkeltplass=true og gjennomforing avsluttet - TILBUD uten startdato - returnerer VENTER_PA_OPPSTART" {
-		ArenaDeltakerStatusConverter(
-			TiltakDeltaker.Status.TILBUD,
-			now,
-			null,
-			null,
-			true,
-			null,
-			erGjennomforingAvsluttet,
-			LocalDate.now(),
-			false
-		).convert().navn shouldBe VENTER_PA_OPPSTART
 	}
 
 	"erEnkeltplass=true og gjennomforing avsluttet - AKTUELL - returnerer IKKE_AKTUELL" {
@@ -869,6 +939,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			true
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -883,6 +954,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -897,6 +969,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe DELTAR
 	}
@@ -911,6 +984,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe IKKE_AKTUELL
 	}
@@ -926,6 +1000,7 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe HAR_SLUTTET
 	}
@@ -940,8 +1015,104 @@ class EnkeltplassStatusConverterTest : StringSpec({
 			null,
 			erGjennomforingAvsluttet,
 			LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
 			false
 		).convert().navn shouldBe HAR_SLUTTET
+	}
+
+	// Tester som verifiserer at det er KUN kombinasjonen
+	// erEnkeltplass=true + gjennomforingStatus=AVSLUTTET + arenaStatus=GJENN
+	// som lar deltakelsen bli DELTAR selv om gjennomføringen har en avsluttende status.
+	// Endrer man én av de tre betingelsene skal deltakelsen overstyres til IKKE_AKTUELL.
+
+	"kun GJENN bypasser avsluttet gjennomforing - erEnkeltplass=true + AVSLUTTET + GJENN + startdato i fortid - returnerer DELTAR" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = true,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe DELTAR
+	}
+
+	"erEnkeltplass=false + AVSLUTTET + GJENN + startdato i fortid - returnerer IKKE_AKTUELL (mangler enkeltplass)" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = false,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe IKKE_AKTUELL
+	}
+
+	"erEnkeltplass=true + AVBRUTT + GJENN + startdato i fortid - returnerer IKKE_AKTUELL (feil gjennomforingStatus)" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = true,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVBRUTT,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe IKKE_AKTUELL
+	}
+
+	"erEnkeltplass=true + AVLYST + GJENN + startdato i fortid - returnerer IKKE_AKTUELL (feil gjennomforingStatus)" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.GJENN,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = true,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVLYST,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe IKKE_AKTUELL
+	}
+
+	"erEnkeltplass=true + AVSLUTTET + JATAKK + startdato i fortid - returnerer IKKE_AKTUELL (feil arenaStatus)" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.JATAKK,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = true,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe IKKE_AKTUELL
+	}
+
+	"erEnkeltplass=true + AVSLUTTET + TILBUD + startdato i fortid - returnerer IKKE_AKTUELL (feil arenaStatus)" {
+		ArenaDeltakerStatusConverter(
+			arenaStatus = TiltakDeltaker.Status.TILBUD,
+			deltakerRegistrertDato = now,
+			deltakerStartdato = yesterday,
+			deltakerSluttdato = null,
+			erEnkeltplass = true,
+			datoStatusEndring = null,
+			erGjennomforingAvsluttet = erGjennomforingAvsluttet,
+			gjennomforingSluttdato = LocalDate.now(),
+			gjennomforingStatus = Gjennomforing.Status.AVSLUTTET,
+			deltakelseKreverGodkjenningLoep = false
+		).convert().navn shouldBe IKKE_AKTUELL
 	}
 }) {
 	companion object {


### PR DESCRIPTION
Endrer logikk etter avklaring med arena. Det er kun AVSLUTT gjennomføringer i kombinasjon med GJENN deltaker som skal gi aktiv status når også datoene tilsier aktiv deltakelse(på enkeltplasser fra arena)

https://trello.com/c/WYQa8pU8/257-endre-mappinglogikk-p%C3%A5-enkeltplass-oppl%C3%A6ringstiltakene